### PR TITLE
Update server/client remote methods and remove readyOnConnect config and ready() client action

### DIFF
--- a/websocket-ballerina/Package.md
+++ b/websocket-ballerina/Package.md
@@ -27,7 +27,7 @@ service class WsService {
 
 **onString**: The received text messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
 
-**onBytes**: The received binary messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
+**onBinaryMessage**: The received binary messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
 
 **onPing and onPong**: The received ping and pong messages are dispatched to these remote methods respectively.
 

--- a/websocket-ballerina/Package.md
+++ b/websocket-ballerina/Package.md
@@ -17,15 +17,15 @@ service /ws on new websocket:Listener(21003) {
         
 service class WsService {
   *websocket:Service;
-  remote isolated function onString(websocket:Caller caller, string data) returns Error? {
+  remote isolated function onTextMessage(websocket:Caller caller, string data) returns websocket:Error? {
       check caller->writeTextMessage(data);
   }
 }              
 ```
 
-**onOpen**: As soon as the WebSocket handshake is completed and the connection is established, the `onConnect` remote method is dispatched.
+**onOpen**: As soon as the WebSocket handshake is completed and the connection is established, the `onOpen` remote method is dispatched.
 
-**onString**: The received text messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
+**onTextMessage**: The received text messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
 
 **onBinaryMessage**: The received binary messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
 

--- a/websocket-ballerina/Package.md
+++ b/websocket-ballerina/Package.md
@@ -18,7 +18,7 @@ service /ws on new websocket:Listener(21003) {
 service class WsService {
   *websocket:Service;
   remote isolated function onString(websocket:Caller caller, string data) returns Error? {
-      check caller->writeString(data);
+      check caller->writeTextMessage(data);
   }
 }              
 ```

--- a/websocket-ballerina/Package.md
+++ b/websocket-ballerina/Package.md
@@ -23,7 +23,7 @@ service class WsService {
 }              
 ```
 
-**onConnect**: As soon as the WebSocket handshake is completed and the connection is established, the `onConnect` remote method is dispatched.
+**onOpen**: As soon as the WebSocket handshake is completed and the connection is established, the `onConnect` remote method is dispatched.
 
 **onString**: The received text messages are dispatched to this remote method. This remote method is not applicable for `SyncClient`
 

--- a/websocket-ballerina/tests/03_push_and_onText.bal
+++ b/websocket-ballerina/tests/03_push_and_onText.bal
@@ -30,14 +30,14 @@ service /onTextString on l2 {
 
 service class WsService1 {
   *Service;
-  remote isolated function onString(Caller caller, string data) returns Error? {
+  remote isolated function onTextMessage(Caller caller, string data) returns Error? {
       check caller->writeString(data);
   }
 }
 
 service class clientPushCallbackService {
     *Service;
-    remote function onString(Caller wsEp, string text) {
+    remote function onTextMessage(Caller wsEp, string text) {
         data = <@untainted>text;
     }
 
@@ -50,7 +50,7 @@ service class clientPushCallbackService {
     }
 }
 
-// Tests string support for writeString and onString
+// Tests string support for writeString and onTextMessage
 @test:Config {}
 public function testString() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21003/onTextString/", new clientPushCallbackService());

--- a/websocket-ballerina/tests/03_push_and_onText.bal
+++ b/websocket-ballerina/tests/03_push_and_onText.bal
@@ -31,7 +31,7 @@ service /onTextString on l2 {
 service class WsService1 {
   *Service;
   remote isolated function onTextMessage(Caller caller, string data) returns Error? {
-      check caller->writeString(data);
+      check caller->writeTextMessage(data);
   }
 }
 
@@ -50,12 +50,12 @@ service class clientPushCallbackService {
     }
 }
 
-// Tests string support for writeString and onTextMessage
+// Tests string support for writeTextMessage and onTextMessage
 @test:Config {}
 public function testString() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21003/onTextString/", new clientPushCallbackService());
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
-   test:assertEquals(data, "Hi", msg = "Failed writeString");
+   test:assertEquals(data, "Hi", msg = "Failed writeTextMessage");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);
 }

--- a/websocket-ballerina/tests/03_push_and_onText.bal
+++ b/websocket-ballerina/tests/03_push_and_onText.bal
@@ -45,7 +45,7 @@ service class clientPushCallbackService {
         io:println(err);
     }
 
-    remote isolated function onConnect(Caller wsEp) {
+    remote isolated function onOpen(Caller wsEp) {
         io:println("On connect resource");
     }
 }

--- a/websocket-ballerina/tests/29_ssl_echo.bal
+++ b/websocket-ballerina/tests/29_ssl_echo.bal
@@ -40,7 +40,7 @@ service /sslEcho on l7 {
 
 service class WsService6 {
   *Service;
-  remote isolated function onString(Caller caller, string data) {
+  remote isolated function onTextMessage(Caller caller, string data) {
        var returnVal = caller->writeString(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -57,7 +57,7 @@ service class WsService6 {
 
 service class sslEchoCallbackService {
    *Service;
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        expectedString = <@untainted>text;
    }
 

--- a/websocket-ballerina/tests/29_ssl_echo.bal
+++ b/websocket-ballerina/tests/29_ssl_echo.bal
@@ -41,7 +41,7 @@ service /sslEcho on l7 {
 service class WsService6 {
   *Service;
   remote isolated function onTextMessage(Caller caller, string data) {
-       var returnVal = caller->writeString(data);
+       var returnVal = caller->writeTextMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -103,7 +103,7 @@ public function sslTextEcho() returns Error? {
                }
            }
        });
-   check wsClient->writeString("Hi madam");
+   check wsClient->writeTextMessage("Hi madam");
    runtime:sleep(0.5);
    test:assertEquals(expectedString, "Hi madam", msg = "Data mismatched");
    test:assertEquals(expectedRawpath, "/sslEcho", msg = "Data mismatched");

--- a/websocket-ballerina/tests/29_ssl_echo.bal
+++ b/websocket-ballerina/tests/29_ssl_echo.bal
@@ -47,7 +47,7 @@ service class WsService6 {
        }
    }
 
-   remote isolated function onBytes(Caller caller, byte[] data) {
+   remote isolated function onBinaryMessage(Caller caller, byte[] data) {
        var returnVal = caller->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -61,7 +61,7 @@ service class sslEchoCallbackService {
        expectedString = <@untainted>text;
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        expectedBinaryData = <@untainted>data;
    }
 

--- a/websocket-ballerina/tests/29_ssl_echo.bal
+++ b/websocket-ballerina/tests/29_ssl_echo.bal
@@ -48,7 +48,7 @@ service class WsService6 {
    }
 
    remote isolated function onBinaryMessage(Caller caller, byte[] data) {
-       var returnVal = caller->writeBytes(data);
+       var returnVal = caller->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -85,7 +85,7 @@ public function sslBinaryEcho() returns Error? {
            }
        });
    byte[] binaryData = [5, 24, 56];
-   check wsClient->writeBytes(binaryData);
+   check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinaryData, binaryData, msg = "Data mismatched");
    test:assertEquals(expectedRawpath, "/sslEcho", msg = "Data mismatched");

--- a/websocket-ballerina/tests/corrupted_frame_client_test.bal
+++ b/websocket-ballerina/tests/corrupted_frame_client_test.bal
@@ -34,7 +34,7 @@ service /onCorruptClient on l31 {
 service class corruptedClService {
   *Service;
   remote isolated function onTextMessage(Caller caller, string data) returns Error? {
-      check caller->writeString("xyz");
+      check caller->writeTextMessage("xyz");
   }
   remote function onError(Caller wsEp, error err) {
       io:println("on server error");
@@ -64,11 +64,11 @@ service class clientCBService {
     }
 }
 
-// Tests string support for writeString and onTextMessage
+// Tests string support for writeTextMessage and onTextMessage
 @test:Config {}
 public function testCorruptedFrameClient() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21104/onCorruptClient/", new clientCBService(), config = {maxFrameSize: 1});
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(data3, "PayloadTooBigError: Max frame length of 1 has been exceeded.", msg = "Failed testCorruptedFrameClient");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/corrupted_frame_client_test.bal
+++ b/websocket-ballerina/tests/corrupted_frame_client_test.bal
@@ -33,7 +33,7 @@ service /onCorruptClient on l31 {
 
 service class corruptedClService {
   *Service;
-  remote isolated function onString(Caller caller, string data) returns Error? {
+  remote isolated function onTextMessage(Caller caller, string data) returns Error? {
       check caller->writeString("xyz");
   }
   remote function onError(Caller wsEp, error err) {
@@ -46,7 +46,7 @@ service class corruptedClService {
 
 service class clientCBService {
     *Service;
-    remote function onString(Caller wsEp, string text) {
+    remote function onTextMessage(Caller wsEp, string text) {
         data2 = <@untainted>text;
     }
 
@@ -64,7 +64,7 @@ service class clientCBService {
     }
 }
 
-// Tests string support for writeString and onString
+// Tests string support for writeString and onTextMessage
 @test:Config {}
 public function testCorruptedFrameClient() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21104/onCorruptClient/", new clientCBService(), config = {maxFrameSize: 1});

--- a/websocket-ballerina/tests/corrupted_frame_client_test.bal
+++ b/websocket-ballerina/tests/corrupted_frame_client_test.bal
@@ -55,7 +55,7 @@ service class clientCBService {
         io:println(<@untainted>err.message());
     }
 
-    remote isolated function onConnect(Caller wsEp) {
+    remote isolated function onOpen(Caller wsEp) {
         io:println("On connect resource");
     }
 

--- a/websocket-ballerina/tests/corrupted_frame_server_test.bal
+++ b/websocket-ballerina/tests/corrupted_frame_server_test.bal
@@ -33,7 +33,7 @@ service /onCorrupt on l30 {
 
 service class corruptedService {
   *Service;
-  remote isolated function onString(Caller caller, string data) returns Error? {
+  remote isolated function onTextMessage(Caller caller, string data) returns Error? {
       check caller->writeString("xyz");
   }
   remote function onError(Caller wsEp, error err) {
@@ -47,7 +47,7 @@ service class corruptedService {
 
 service class clientCbackService {
     *Service;
-    remote function onString(Caller wsEp, string text) {
+    remote function onTextMessage(Caller wsEp, string text) {
         data2 = <@untainted>text;
     }
 
@@ -64,7 +64,7 @@ service class clientCbackService {
     }
 }
 
-// Tests string support for writeString and onString
+// Tests the error when a corrupted frame is sent
 @test:Config {}
 public function testCorruptedFrame() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21103/onCorrupt/", new clientCbackService());

--- a/websocket-ballerina/tests/corrupted_frame_server_test.bal
+++ b/websocket-ballerina/tests/corrupted_frame_server_test.bal
@@ -55,7 +55,7 @@ service class clientCbackService {
         io:println(<@untainted>err.message());
     }
 
-    remote isolated function onConnect(Caller wsEp) {
+    remote isolated function onOpen(Caller wsEp) {
         io:println("On connect resource");
     }
 

--- a/websocket-ballerina/tests/corrupted_frame_server_test.bal
+++ b/websocket-ballerina/tests/corrupted_frame_server_test.bal
@@ -34,7 +34,7 @@ service /onCorrupt on l30 {
 service class corruptedService {
   *Service;
   remote isolated function onTextMessage(Caller caller, string data) returns Error? {
-      check caller->writeString("xyz");
+      check caller->writeTextMessage("xyz");
   }
   remote function onError(Caller wsEp, error err) {
       io:println("on server error");
@@ -68,7 +68,7 @@ service class clientCbackService {
 @test:Config {}
 public function testCorruptedFrame() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21103/onCorrupt/", new clientCbackService());
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(data2, "PayloadTooBigError: Max frame length of 1 has been exceeded.", msg = "Failed testCorruptedFrame");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/sync_client_test_bytes.bal
+++ b/websocket-ballerina/tests/sync_client_test_bytes.bal
@@ -31,7 +31,7 @@ service /onTextBytes on l8 {
 service class WsServiceSyncBytes {
   *Service;
   remote isolated function onBinaryMessage(Caller caller, byte[] data) returns Error? {
-      check caller->writeBytes(data);
+      check caller->writeBinaryMessage(data);
   }
 
   remote isolated function onClose(Caller caller, string data) returns Error? {
@@ -73,13 +73,13 @@ public function testSyncClientByteArray() returns Error? {
    worker w2 {
       io:println("Waiting till client starts reading byte[].");
       runtime:sleep(2);
-      var resp1 = wsClient->writeBytes("Hello".toBytes());
+      var resp1 = wsClient->writeBinaryMessage("Hello".toBytes());
       runtime:sleep(2);
-      var resp2 = wsClient->writeBytes("Hello2".toBytes());
+      var resp2 = wsClient->writeBinaryMessage("Hello2".toBytes());
       runtime:sleep(2);
-      var resp3 = wsClient->writeBytes("Hello3".toBytes());
-      var resp4 = wsClient->writeBytes("Hello4".toBytes());
-      var resp5 = wsClient->writeBytes("Hello5".toBytes());
+      var resp3 = wsClient->writeBinaryMessage("Hello3".toBytes());
+      var resp4 = wsClient->writeBinaryMessage("Hello4".toBytes());
+      var resp5 = wsClient->writeBinaryMessage("Hello5".toBytes());
    }
    _ = wait {w1, w2};
    string msg = "[72,101,108,108,111][72,101,108,108,111,50][72,101,108,108,111,51][72,101,108,108,111,52][72,101,108,108,111,53]";

--- a/websocket-ballerina/tests/sync_client_test_bytes.bal
+++ b/websocket-ballerina/tests/sync_client_test_bytes.bal
@@ -47,23 +47,23 @@ public function testSyncClientByteArray() returns Error? {
    }
    worker w1 {
       io:println("Reading message starting: sync byte[] client");
-      byte[] resp1 = checkpanic wsClient->readBytes();
+      byte[] resp1 = checkpanic wsClient->readBinaryMessage();
       aggregatedByteOutput = aggregatedByteOutput + resp1.toString();
       io:println("1st response received at sync byte[] client :" + resp1.toString());
 
-      byte[] resp2 = checkpanic wsClient->readBytes();
+      byte[] resp2 = checkpanic wsClient->readBinaryMessage();
       aggregatedByteOutput = aggregatedByteOutput + resp2.toString();
       io:println("2nd response received at sync byte[] client :" + resp2.toString());
 
-      byte[] resp3 = checkpanic wsClient->readBytes();
+      byte[] resp3 = checkpanic wsClient->readBinaryMessage();
       aggregatedByteOutput = aggregatedByteOutput + resp3.toString();
       io:println("3rd response received at sync byte[] client :" + resp3.toString());
 
-      byte[] resp4 = checkpanic wsClient->readBytes();
+      byte[] resp4 = checkpanic wsClient->readBinaryMessage();
       aggregatedByteOutput = aggregatedByteOutput + resp4.toString();
       io:println("4th response received at sync byte[] client :" + resp4.toString());
 
-      byte[] resp5 = checkpanic wsClient->readBytes();
+      byte[] resp5 = checkpanic wsClient->readBinaryMessage();
       aggregatedByteOutput = aggregatedByteOutput + resp5.toString();
       io:println("final response received at sync byte[] client :" + resp5.toString());
    }

--- a/websocket-ballerina/tests/sync_client_test_bytes.bal
+++ b/websocket-ballerina/tests/sync_client_test_bytes.bal
@@ -35,7 +35,7 @@ service class WsServiceSyncBytes {
   }
 
   remote isolated function onClose(Caller caller, string data) returns Error? {
-        check caller->writeString(data);
+        check caller->writeTextMessage(data);
   }
 }
 

--- a/websocket-ballerina/tests/sync_client_test_bytes.bal
+++ b/websocket-ballerina/tests/sync_client_test_bytes.bal
@@ -30,7 +30,7 @@ service /onTextBytes on l8 {
 
 service class WsServiceSyncBytes {
   *Service;
-  remote isolated function onBytes(Caller caller, byte[] data) returns Error? {
+  remote isolated function onBinaryMessage(Caller caller, byte[] data) returns Error? {
       check caller->writeBytes(data);
   }
 

--- a/websocket-ballerina/tests/sync_client_test_text.bal
+++ b/websocket-ballerina/tests/sync_client_test_text.bal
@@ -29,11 +29,11 @@ service /onTextString on l11 {
 service class WsServiceSync {
   *Service;
   remote isolated function onTextMessage(Caller caller, string data) returns Error? {
-      check caller->writeString(data);
+      check caller->writeTextMessage(data);
   }
 
   remote isolated function onClose(Caller caller, string data) returns Error? {
-        check caller->writeString(data);
+        check caller->writeTextMessage(data);
   }
 }
 
@@ -74,13 +74,13 @@ public function testSyncClient() returns Error? {
    worker w2 {
       io:println("Waiting till client starts reading text.");
       runtime:sleep(2);
-      var resp1 = wsClient->writeString("Hi world1");
+      var resp1 = wsClient->writeTextMessage("Hi world1");
       runtime:sleep(2);
-      var resp2 = wsClient->writeString("Hi world2");
+      var resp2 = wsClient->writeTextMessage("Hi world2");
       runtime:sleep(2);
-      var resp3 = wsClient->writeString("Hi world3");
-      var resp4 = wsClient->writeString("Hi world4");
-      var resp5 = wsClient->writeString("Hi world5");
+      var resp3 = wsClient->writeTextMessage("Hi world3");
+      var resp4 = wsClient->writeTextMessage("Hi world4");
+      var resp5 = wsClient->writeTextMessage("Hi world5");
    }
    _ = wait {w1, w2};
    string msg = "Hi world1Hi world2Hi world3Hi world4Hi world5";

--- a/websocket-ballerina/tests/sync_client_test_text.bal
+++ b/websocket-ballerina/tests/sync_client_test_text.bal
@@ -28,7 +28,7 @@ service /onTextString on l11 {
 
 service class WsServiceSync {
   *Service;
-  remote isolated function onString(Caller caller, string data) returns Error? {
+  remote isolated function onTextMessage(Caller caller, string data) returns Error? {
       check caller->writeString(data);
   }
 

--- a/websocket-ballerina/tests/sync_client_test_text.bal
+++ b/websocket-ballerina/tests/sync_client_test_text.bal
@@ -46,25 +46,25 @@ public function testSyncClient() returns Error? {
    worker w1 {
       io:println("Reading message starting: sync text client");
 
-      string resp1 = checkpanic wsClient->readString();
+      string resp1 = checkpanic wsClient->readTextMessage();
       aggregatedTextOutput = aggregatedTextOutput + resp1;
       io:println("1st response received at sync text client :" + resp1);
 
-      var resp2 = checkpanic wsClient->readString();
+      var resp2 = checkpanic wsClient->readTextMessage();
       aggregatedTextOutput = aggregatedTextOutput + resp2;
       io:println("2nd response received at sync text client :" + resp2);
 
-      var resp3 = checkpanic wsClient->readString();
+      var resp3 = checkpanic wsClient->readTextMessage();
       aggregatedTextOutput = aggregatedTextOutput + resp3;
       io:println("3rd response received at sync text client :" + resp3);
 
       runtime:sleep(3);
 
-      var resp4 = checkpanic wsClient->readString();
+      var resp4 = checkpanic wsClient->readTextMessage();
       aggregatedTextOutput = aggregatedTextOutput + resp4;
       io:println("4th response received at sync text client :" + resp4);
 
-      var resp5 = checkpanic wsClient->readString();
+      var resp5 = checkpanic wsClient->readTextMessage();
       aggregatedTextOutput = aggregatedTextOutput + resp5;
       io:println("Final response received at sync text client :" + resp5);
    }

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -126,19 +126,8 @@ public function testConnectionClosedError() returns Error? {
 @test:Config {}
 public function testHandshakeError() returns Error? {
    AsyncClient wsClientEp = check new ("ws://localhost:21030/websocket", new errorResourceService(), config);
+   var resp = wsClientEp->writeTextMessage("text");
    runtime:sleep(0.5);
    test:assertEquals(errMessage, "InvalidHandshakeError: Invalid subprotocol. Actual: null. Expected one of: xml");
 }
 
-// Tests the ready function using the WebSocket client. When `readyOnConnect` is true,
-// calls the `ready()` function.
-@test:Config {}
-public function testReadyOnConnect() returns Error? {
-   AsyncClient wsClientEp = check new ("ws://localhost:21030/websocket", new errorResourceService());
-   var err = wsClientEp->ready();
-   if (err is error) {
-       test:assertEquals(err.message(), "GenericError: Already started reading frames");
-   } else {
-       test:assertFail("Mismatched output");
-   }
-}

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -56,7 +56,7 @@ service class ErrorServer {
        }
    }
 
-   remote isolated function onString(Caller caller, string text) {
+   remote isolated function onTextMessage(Caller caller, string text) {
        var err = caller->writeString(text);
        if (err is Error) {
            io:println("Error occurred when sending text message" + err.message());

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -57,7 +57,7 @@ service class ErrorServer {
    }
 
    remote isolated function onTextMessage(Caller caller, string text) {
-       var err = caller->writeString(text);
+       var err = caller->writeTextMessage(text);
        if (err is Error) {
            io:println("Error occurred when sending text message" + err.message());
        }
@@ -114,7 +114,7 @@ public function testConnectionClosedError() returns Error? {
    AsyncClient wsClientEp = check new ("ws://localhost:21030/websocket", new errorResourceService());
    error? result = wsClientEp->close(timeoutInSeconds = 0);
    runtime:sleep(2);
-   var err = wsClientEp->writeString("some");
+   var err = wsClientEp->writeTextMessage("some");
    if (err is error) {
        test:assertEquals(err.message(), "ConnectionClosureError: Close frame already sent. Cannot push text data!");
    } else {

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -38,7 +38,7 @@ service /websocket on l14 {
 
 service class ErrorServer {
   *Service;
-   remote isolated function onConnect(Caller caller) {
+   remote isolated function onOpen(Caller caller) {
        io:println("The Connection ID: " + caller.getConnectionId());
    }
 

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -64,7 +64,7 @@ service class ErrorServer {
    }
 
    remote isolated function onBinaryMessage(Caller caller, byte[] data) {
-       var returnVal = caller->writeBytes(data);
+       var returnVal = caller->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -63,7 +63,7 @@ service class ErrorServer {
        }
    }
 
-   remote isolated function onBytes(Caller caller, byte[] data) {
+   remote isolated function onBinaryMessage(Caller caller, byte[] data) {
        var returnVal = caller->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;

--- a/websocket-ballerina/tests/websocket_client_failure.bal
+++ b/websocket-ballerina/tests/websocket_client_failure.bal
@@ -28,10 +28,8 @@ service class errorHandlingService {
 // Tests the client initialization failing in a resource.
 @test:Config {}
 public function testClientEndpointFailureInResource() returns Error? {
-   AsyncClient wsClientEp = check new ("ws://localhost:21010/websocketxyz", new errorHandlingService(), {
-           readyOnConnect: false
-       });
-   var err = wsClientEp->ready();
+   AsyncClient wsClientEp = check new ("ws://localhost:21010/websocketxyz", new errorHandlingService());
+   var err = wsClientEp->writeTextMessage("text");
    if (err is Error) {
        test:assertEquals(err.message(), "ConnectionError: The WebSocket connection has not been made");
    } else {

--- a/websocket-ballerina/tests/websocket_client_service.bal
+++ b/websocket-ballerina/tests/websocket_client_service.bal
@@ -59,7 +59,7 @@ public function testClientSuccessWithoutService() returns Error? {
 public function testClientSuccessWithWebSocketClientService() returns Error? {
    isClientConnectionOpen = false;
    AsyncClient wsClient = check new("ws://localhost:21021/client/service/bbe", new ClientService200());
-   check wsClient->writeString("Client worked");
+   check wsClient->writeTextMessage("Client worked");
    runtime:sleep(0.5);
    test:assertTrue(isClientConnectionOpen);
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/websocket_client_service.bal
+++ b/websocket-ballerina/tests/websocket_client_service.bal
@@ -35,13 +35,13 @@ service class clientFailure200 {
 
 service class callback200 {
    *Service;
-   remote function onString(string caller, string text) {
+   remote function onTextMessage(string caller, string text) {
    }
 }
 
 service class ClientService200 {
    *Service;
-   remote function onString(Caller caller, string text) {
+   remote function onTextMessage(Caller caller, string text) {
    }
 }
 

--- a/websocket-ballerina/tests/websocket_client_service.bal
+++ b/websocket-ballerina/tests/websocket_client_service.bal
@@ -28,7 +28,7 @@ service /'client/'service on l15 {
 
 service class clientFailure200 {
   *Service;
-  remote function onConnect(Caller wsEp) {
+  remote function onOpen(Caller wsEp) {
        isClientConnectionOpen = true;
    }
 }

--- a/websocket-ballerina/tests/websocket_custom_headers_test.bal
+++ b/websocket-ballerina/tests/websocket_custom_headers_test.bal
@@ -68,7 +68,7 @@ service class MyWSService2 {
 @test:Config {}
 public function testIsOpenCloseCalled() returns error? {
     AsyncClient wsClient = check new("ws://localhost:21001/isOpen/abc;a=4;b=5/barz/xyz/abc/rre?para1=value1");
-    check wsClient->writeString("Hi");
+    check wsClient->writeTextMessage("Hi");
     runtime:sleep(0.5);
 
     test:assertEquals(output, "In service 1 onTextMessage isOpen false");
@@ -83,7 +83,7 @@ public function testIsOpenCloseCalled() returns error? {
     }
 
     AsyncClient wsClient2 = check new("ws://localhost:21001/isOpen/abc/barz/tuv/abc/cav/");
-    check wsClient2->writeString("Hi");
+    check wsClient2->writeTextMessage("Hi");
     runtime:sleep(0.5);
     test:assertEquals(output, "In service 2 onTextMessage isOpen false");
     test:assertEquals(pathParam, "tuv");

--- a/websocket-ballerina/tests/websocket_custom_headers_test.bal
+++ b/websocket-ballerina/tests/websocket_custom_headers_test.bal
@@ -18,7 +18,7 @@ import ballerina/lang.runtime as runtime;
 import ballerina/test;
 import ballerina/http;
 
-http:Listener hl = check new(21001);
+http:Listener hl = new(21001);
 listener Listener socketListener = new(<@untainted> hl);
 string output = "";
 string errorMsg = "";
@@ -50,17 +50,17 @@ service class MyWSService {
   public function init(map<string> customHeaders) {
      self.customHeaders = customHeaders;
   }
-  remote function onString(Caller caller, string text) {
+  remote function onTextMessage(Caller caller, string text) {
       Error? err = caller->close(timeoutInSeconds = 0);
-      output = <@untainted>("In service 1 onString isOpen " + caller.isOpen().toString());
+      output = <@untainted>("In service 1 onTextMessage isOpen " + caller.isOpen().toString());
   }
 }
 
 service class MyWSService2 {
   *Service;
-  remote function onString(Caller caller, string text) {
+  remote function onTextMessage(Caller caller, string text) {
       Error? err = caller->close(timeoutInSeconds = 0);
-      output = <@untainted>("In service 2 onString isOpen " + caller.isOpen().toString());
+      output = <@untainted>("In service 2 onTextMessage isOpen " + caller.isOpen().toString());
   }
 }
 
@@ -71,7 +71,7 @@ public function testIsOpenCloseCalled() returns error? {
     check wsClient->writeString("Hi");
     runtime:sleep(0.5);
 
-    test:assertEquals(output, "In service 1 onString isOpen false");
+    test:assertEquals(output, "In service 1 onTextMessage isOpen false");
     test:assertEquals(pathParam, "xyz");
     test:assertEquals(queryParam, "value1");
 
@@ -85,7 +85,7 @@ public function testIsOpenCloseCalled() returns error? {
     AsyncClient wsClient2 = check new("ws://localhost:21001/isOpen/abc/barz/tuv/abc/cav/");
     check wsClient2->writeString("Hi");
     runtime:sleep(0.5);
-    test:assertEquals(output, "In service 2 onString isOpen false");
+    test:assertEquals(output, "In service 2 onTextMessage isOpen false");
     test:assertEquals(pathParam, "tuv");
 }
 

--- a/websocket-ballerina/tests/websocket_error_log_service.bal
+++ b/websocket-ballerina/tests/websocket_error_log_service.bal
@@ -28,7 +28,7 @@ service class ErrorService {
    remote function onConnect(Caller ep) {
    }
 
-   remote function onString(Caller ep, string text) {
+   remote function onTextMessage(Caller ep, string text) {
        var returnVal = ep->writeString(text);
        if (returnVal is Error) {
            panic <error>returnVal;

--- a/websocket-ballerina/tests/websocket_error_log_service.bal
+++ b/websocket-ballerina/tests/websocket_error_log_service.bal
@@ -25,7 +25,7 @@ service UpgradeService /'error/ws on l16 {
 
 service class ErrorService {
    *Service;
-   remote function onConnect(Caller ep) {
+   remote function onOpen(Caller ep) {
    }
 
    remote function onTextMessage(Caller ep, string text) {

--- a/websocket-ballerina/tests/websocket_error_log_service.bal
+++ b/websocket-ballerina/tests/websocket_error_log_service.bal
@@ -29,7 +29,7 @@ service class ErrorService {
    }
 
    remote function onTextMessage(Caller ep, string text) {
-       var returnVal = ep->writeString(text);
+       var returnVal = ep->writeTextMessage(text);
        if (returnVal is Error) {
            panic <error>returnVal;
        }

--- a/websocket-ballerina/tests/websocket_missing_resources.bal
+++ b/websocket-ballerina/tests/websocket_missing_resources.bal
@@ -46,14 +46,14 @@ service /onlyOnText on l25 {
 
 service class OnlyOnText {
    *Service;
-   remote function onString(Caller caller, string data) returns Error? {
+   remote function onTextMessage(Caller caller, string data) returns Error? {
        check caller->writeString(data);
    }
 }
 
 service class callbackService {
    *Service;
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        expectedData = <@untainted>text;
    }
 
@@ -66,7 +66,7 @@ service class callbackService {
    }
 }
 
-// Tests behavior when onString resource is missing and a text message is received
+// Tests behavior when onTextMessage resource is missing and a text message is received
 @test:Config {}
 public function testMissingOnText() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21005/onlyOnBinary", new callbackService());

--- a/websocket-ballerina/tests/websocket_missing_resources.bal
+++ b/websocket-ballerina/tests/websocket_missing_resources.bal
@@ -33,7 +33,7 @@ service /onlyOnBinary on l17 {
 service class OnlyOnBinary {
   *Service;
    remote function onBinaryMessage(Caller caller, byte[] data) returns Error? {
-       check caller->writeBytes(data);
+       check caller->writeBinaryMessage(data);
    }
 }
 
@@ -75,7 +75,7 @@ public function testMissingOnText() returns Error? {
    check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(expectedData, "", msg = "Data mismatched");
-   check wsClient->writeBytes(binaryData);
+   check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinData, binaryData, msg = "Data mismatched");
    error? result = wsClient->close(timeoutInSeconds = 0);
@@ -90,7 +90,7 @@ public function testMissingOnPong() returns Error? {
    check wsClient->pong(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedPingBinaryData, expectedBinData, msg = "Data mismatched");
-   check wsClient->writeBytes(binaryData);
+   check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinData, binaryData, msg = "Data mismatched");
    error? result = wsClient->close(timeoutInSeconds = 0);
@@ -104,7 +104,7 @@ public function testMissingOnBinary() returns Error? {
    expectedBinData = [];
    byte[] expectedBinData = [];
    expectedData = "";
-   check wsClient->writeBytes(binaryData);
+   check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinData, expectedBinData, msg = "Data mismatched");
    check wsClient->writeTextMessage("Hi");

--- a/websocket-ballerina/tests/websocket_missing_resources.bal
+++ b/websocket-ballerina/tests/websocket_missing_resources.bal
@@ -47,7 +47,7 @@ service /onlyOnText on l25 {
 service class OnlyOnText {
    *Service;
    remote function onTextMessage(Caller caller, string data) returns Error? {
-       check caller->writeString(data);
+       check caller->writeTextMessage(data);
    }
 }
 
@@ -72,7 +72,7 @@ public function testMissingOnText() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21005/onlyOnBinary", new callbackService());
    expectedData = "";
    byte[] binaryData = [5, 24, 56, 243];
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(expectedData, "", msg = "Data mismatched");
    check wsClient->writeBytes(binaryData);
@@ -107,7 +107,7 @@ public function testMissingOnBinary() returns Error? {
    check wsClient->writeBytes(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinData, expectedBinData, msg = "Data mismatched");
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(expectedData, "Hi", msg = "Data mismatched");
    error? result = wsClient->close(timeoutInSeconds = 0);
@@ -119,7 +119,7 @@ public function testMissingOnIdleTimeout() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21006/onlyOnText", new callbackService());
    expectedData = "";
    runtime:sleep(0.5);
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(expectedData, "Hi", msg = "Data mismatched");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/websocket_missing_resources.bal
+++ b/websocket-ballerina/tests/websocket_missing_resources.bal
@@ -32,7 +32,7 @@ service /onlyOnBinary on l17 {
 }
 service class OnlyOnBinary {
   *Service;
-   remote function onBytes(Caller caller, byte[] data) returns Error? {
+   remote function onBinaryMessage(Caller caller, byte[] data) returns Error? {
        check caller->writeBytes(data);
    }
 }
@@ -57,7 +57,7 @@ service class callbackService {
        expectedData = <@untainted>text;
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        expectedBinData = <@untainted>data;
    }
 
@@ -96,7 +96,7 @@ public function testMissingOnPong() returns Error? {
    error? result = wsClient->close(timeoutInSeconds = 0);
 }
 
-// Tests behavior when onBytes resource is missing and binary message is received
+// Tests behavior when onBinaryMessage resource is missing and binary message is received
 @test:Config {}
 public function testMissingOnBinary() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21006/onlyOnText", new callbackService());
@@ -113,7 +113,7 @@ public function testMissingOnBinary() returns Error? {
    error? result = wsClient->close(timeoutInSeconds = 0);
 }
 
-// Tests behavior when onBytes resource is missing and binary message is received
+// Tests behavior when onBinaryMessage resource is missing and binary message is received
 @test:Config {}
 public function testMissingOnIdleTimeout() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21006/onlyOnText", new callbackService());

--- a/websocket-ballerina/tests/websocket_on_binary_continuation.bal
+++ b/websocket-ballerina/tests/websocket_on_binary_continuation.bal
@@ -30,7 +30,7 @@
 //    remote function onBinaryMessage(Caller caller, byte[] data, boolean finalFrame) {
 //        if (finalFrame) {
 //            appendToArray(<@untainted> data, content);
-//            var returnVal = caller->writeBytes(content);
+//            var returnVal = caller->writeBinaryMessage(content);
 //            if (returnVal is Error) {
 //                panic <error> returnVal;
 //            }
@@ -62,9 +62,9 @@
 //    string[] values = ["<note>", "<to>", "Tove", "</to>"];
 //    AsyncClient wsClient = new ("ws://localhost:21007/onBinaryContinuation", new continuationService());
 //    foreach string value in values {
-//        checkpanic wsClient->writeBytes(value.toBytes(), false);
+//        checkpanic wsClient->writeBinaryMessage(value.toBytes(), false);
 //    }
-//    checkpanic wsClient->writeBytes("</note>".toBytes(), true);
+//    checkpanic wsClient->writeBinaryMessage("</note>".toBytes(), true);
 //    runtime:sleep(500);
 //    string|error value = 'string:fromBytes(binaryContent);
 //    string s = value is error ? value.toString() : value.toString();

--- a/websocket-ballerina/tests/websocket_on_binary_continuation.bal
+++ b/websocket-ballerina/tests/websocket_on_binary_continuation.bal
@@ -27,7 +27,7 @@
 // }
 // service class OnBinaryContinuation {
 //    *Service;
-//    remote function onBytes(Caller caller, byte[] data, boolean finalFrame) {
+//    remote function onBinaryMessage(Caller caller, byte[] data, boolean finalFrame) {
 //        if (finalFrame) {
 //            appendToArray(<@untainted> data, content);
 //            var returnVal = caller->writeBytes(content);
@@ -50,7 +50,7 @@
 // }
 
 // service class continuationService {
-//    remote function onBytes(Caller caller, byte[] data, boolean finalFrame) {
+//    remote function onBinaryMessage(Caller caller, byte[] data, boolean finalFrame) {
 //        binaryContent = <@untainted>data;
 //    }
 // }

--- a/websocket-ballerina/tests/websocket_ping_pong.bal
+++ b/websocket-ballerina/tests/websocket_ping_pong.bal
@@ -28,7 +28,7 @@ service /pingpong/ws on l19 {
 
 service class PingPongService {
   *Service;
-   remote isolated function onConnect(Caller caller) {
+   remote isolated function onOpen(Caller caller) {
    }
 
    remote isolated function onPing(Caller caller, byte[] localData) {

--- a/websocket-ballerina/tests/websocket_pushText_failure.bal
+++ b/websocket-ballerina/tests/websocket_pushText_failure.bal
@@ -29,14 +29,14 @@ service class PushTextFailureService {
    *Service;
    remote function onConnect(Caller caller) {
        Error? err1 = caller->close(timeoutInSeconds = 0);
-       var err = caller->writeString("hey");
+       var err = caller->writeTextMessage("hey");
        if (err is Error) {
            errorMsg2 = <@untainted>err.message();
        }
    }
 }
 
-// Checks for the log that is printed when writeString fails.
+// Checks for the log that is printed when writeTextMessage fails.
 @test:Config {}
 public function pushTextFailure() returns Error? {
    AsyncClient wsClient = check new("ws://localhost:21008/pushTextFailureService");

--- a/websocket-ballerina/tests/websocket_pushText_failure.bal
+++ b/websocket-ballerina/tests/websocket_pushText_failure.bal
@@ -27,7 +27,7 @@ service /pushTextFailureService on l20 {
 
 service class PushTextFailureService {
    *Service;
-   remote function onConnect(Caller caller) {
+   remote function onOpen(Caller caller) {
        Error? err1 = caller->close(timeoutInSeconds = 0);
        var err = caller->writeTextMessage("hey");
        if (err is Error) {

--- a/websocket-ballerina/tests/websocket_server_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_server_exceptions.bal
@@ -27,7 +27,7 @@
 // }
 // service class ServerError {
 //    *Service;
-//    remote function onString(Caller caller, string text) {
+//    remote function onTextMessage(Caller caller, string text) {
 //        checkpanic caller->writeString("Hello World!", false);
 //        string hello = "hello";
 //        byte[] data = hello.toBytes();

--- a/websocket-ballerina/tests/websocket_server_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_server_exceptions.bal
@@ -28,7 +28,7 @@
 // service class ServerError {
 //    *Service;
 //    remote function onTextMessage(Caller caller, string text) {
-//        checkpanic caller->writeString("Hello World!", false);
+//        checkpanic caller->writeTextMessage("Hello World!", false);
 //        string hello = "hello";
 //        byte[] data = hello.toBytes();
 //        var err = caller->writeBytes(data, false);
@@ -55,7 +55,7 @@
 // @test:Config {}
 // public function testContinuationFrameError() {
 //    AsyncClient wsClientEp = new ("ws://localhost:21031/server/errors");
-//    var err = trap wsClientEp->writeString("Hi kalai");
+//    var err = trap wsClientEp->writeTextMessage("Hi kalai");
 //    runtime:sleep(500);
 //    test:assertEquals(serverOutput, "InvalidContinuationFrameError: Cannot interrupt WebSocket" +
 //        " text frame continuation");

--- a/websocket-ballerina/tests/websocket_server_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_server_exceptions.bal
@@ -39,7 +39,7 @@
 //        }
 //    }
 
-//    remote function onBytes(Caller caller, byte[] data, boolean finalFrame) {
+//    remote function onBinaryMessage(Caller caller, byte[] data, boolean finalFrame) {
 //        var returnVal = caller->writeBytes(data, finalFrame);
 //        if (returnVal is Error) {
 //            panic <error>returnVal;

--- a/websocket-ballerina/tests/websocket_server_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_server_exceptions.bal
@@ -31,7 +31,7 @@
 //        checkpanic caller->writeTextMessage("Hello World!", false);
 //        string hello = "hello";
 //        byte[] data = hello.toBytes();
-//        var err = caller->writeBytes(data, false);
+//        var err = caller->writeBinaryMessage(data, false);
 //        if (err is error) {
 //            serverOutput = <@untainted>err.message();
 //        } else {
@@ -40,7 +40,7 @@
 //    }
 
 //    remote function onBinaryMessage(Caller caller, byte[] data, boolean finalFrame) {
-//        var returnVal = caller->writeBytes(data, finalFrame);
+//        var returnVal = caller->writeBinaryMessage(data, finalFrame);
 //        if (returnVal is Error) {
 //            panic <error>returnVal;
 //        }

--- a/websocket-ballerina/tests/websocket_simple_proxy_server.bal
+++ b/websocket-ballerina/tests/websocket_simple_proxy_server.bal
@@ -29,13 +29,7 @@ service / on l22 {
 service class ProxyService {
   *Service;
   remote function onOpen(Caller wsEp) returns Error? {
-       AsyncClient wsClientEp = check new ("ws://localhost:21019/websocket", new clientCallbackService9(), {
-               readyOnConnect: false
-           });
-       var returnVal = wsClientEp->ready();
-       if (returnVal is Error) {
-           panic <error>returnVal;
-       }
+       AsyncClient wsClientEp = check new ("ws://localhost:21019/websocket", new clientCallbackService9());
    }
 
    remote function onTextMessage(Caller wsEp, string text) {

--- a/websocket-ballerina/tests/websocket_simple_proxy_server.bal
+++ b/websocket-ballerina/tests/websocket_simple_proxy_server.bal
@@ -46,7 +46,7 @@ service class ProxyService {
    }
 
    remote function onBinaryMessage(Caller wsEp, byte[] data) {
-       var returnVal = wsEp->writeBytes(data);
+       var returnVal = wsEp->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -82,7 +82,7 @@ service class ProxyService2 {
    }
 
    remote function onBinaryMessage(Caller caller, byte[] data) {
-       var returnVal = caller->writeBytes(data);
+       var returnVal = caller->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -99,7 +99,7 @@ service class clientCallbackService9 {
    }
 
    remote function onBinaryMessage(Caller wsEp, byte[] data) {
-       var returnVal = wsEp->writeBytes(data);
+       var returnVal = wsEp->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -146,7 +146,7 @@ public function testSendText() returns Error? {
 public function testSendBinary() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21018", new proxyCallbackService());
    byte[] binaryData = [5, 24, 56, 243];
-   check wsClient->writeBytes(binaryData);
+   check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinaryData, binaryData, msg = "Data mismatched");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/websocket_simple_proxy_server.bal
+++ b/websocket-ballerina/tests/websocket_simple_proxy_server.bal
@@ -45,7 +45,7 @@ service class ProxyService {
        }
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        var returnVal = wsEp->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -81,7 +81,7 @@ service class ProxyService2 {
        }
    }
 
-   remote function onBytes(Caller caller, byte[] data) {
+   remote function onBinaryMessage(Caller caller, byte[] data) {
        var returnVal = caller->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -98,7 +98,7 @@ service class clientCallbackService9 {
        }
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        var returnVal = wsEp->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -119,7 +119,7 @@ service class proxyCallbackService {
        proxyData = <@untainted>text;
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        expectedBinaryData = <@untainted>data;
    }
 

--- a/websocket-ballerina/tests/websocket_simple_proxy_server.bal
+++ b/websocket-ballerina/tests/websocket_simple_proxy_server.bal
@@ -28,7 +28,7 @@ service / on l22 {
 
 service class ProxyService {
   *Service;
-  remote function onConnect(Caller wsEp) returns Error? {
+  remote function onOpen(Caller wsEp) returns Error? {
        AsyncClient wsClientEp = check new ("ws://localhost:21019/websocket", new clientCallbackService9(), {
                readyOnConnect: false
            });
@@ -70,7 +70,7 @@ service /websocket on l26 {
 
 service class ProxyService2 {
    *Service;
-   remote function onConnect(Caller caller) {
+   remote function onOpen(Caller caller) {
        io:println("The Connection ID: " + caller.getConnectionId());
    }
 

--- a/websocket-ballerina/tests/websocket_simple_proxy_server.bal
+++ b/websocket-ballerina/tests/websocket_simple_proxy_server.bal
@@ -39,7 +39,7 @@ service class ProxyService {
    }
 
    remote function onTextMessage(Caller wsEp, string text) {
-       var returnVal = wsEp->writeString(text);
+       var returnVal = wsEp->writeTextMessage(text);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -75,7 +75,7 @@ service class ProxyService2 {
    }
 
    remote function onTextMessage(Caller caller, string text) {
-       var err = caller->writeString(text);
+       var err = caller->writeTextMessage(text);
        if (err is Error) {
            io:println("Error occurred when sending text message: ", err);
        }
@@ -92,7 +92,7 @@ service class ProxyService2 {
 service class clientCallbackService9 {
    *Service;
    remote function onTextMessage(Caller wsEp, string text) {
-       var returnVal = wsEp->writeString(text);
+       var returnVal = wsEp->writeTextMessage(text);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -135,7 +135,7 @@ service class proxyCallbackService {
 @test:Config {}
 public function testSendText() returns Error? {
    AsyncClient wsClient = check new ("ws://localhost:21018", new proxyCallbackService());
-   check wsClient->writeString("Hi kalai");
+   check wsClient->writeTextMessage("Hi kalai");
    runtime:sleep(0.5);
    test:assertEquals(proxyData, "Hi kalai", msg = "Data mismatched");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/websocket_simple_proxy_server.bal
+++ b/websocket-ballerina/tests/websocket_simple_proxy_server.bal
@@ -38,7 +38,7 @@ service class ProxyService {
        }
    }
 
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        var returnVal = wsEp->writeString(text);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -74,7 +74,7 @@ service class ProxyService2 {
        io:println("The Connection ID: " + caller.getConnectionId());
    }
 
-   remote function onString(Caller caller, string text) {
+   remote function onTextMessage(Caller caller, string text) {
        var err = caller->writeString(text);
        if (err is Error) {
            io:println("Error occurred when sending text message: ", err);
@@ -91,7 +91,7 @@ service class ProxyService2 {
 
 service class clientCallbackService9 {
    *Service;
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        var returnVal = wsEp->writeString(text);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -115,7 +115,7 @@ service class clientCallbackService9 {
 
 service class proxyCallbackService {
    *Service;
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        proxyData = <@untainted>text;
    }
 

--- a/websocket-ballerina/tests/websocket_simple_server_without_ping_resource.bal
+++ b/websocket-ballerina/tests/websocket_simple_server_without_ping_resource.bal
@@ -28,7 +28,7 @@ service / on l23 {
 
 service class TestService {
    *Service;
-   remote function onConnect(Caller wsEp) {
+   remote function onOpen(Caller wsEp) {
        io:println("New Client Connected");
    }
 }

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -59,7 +59,7 @@ service class SslProxy {
    }
 
    remote function onBinaryMessage(Caller wsEp, byte[] data) {
-       var returnVal = wsEp->writeBytes(data);
+       var returnVal = wsEp->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -83,7 +83,7 @@ service class sslClientService {
    }
 
    remote function onBinaryMessage(Caller wsEp, byte[] data) {
-       var returnVal = wsEp->writeBytes(data);
+       var returnVal = wsEp->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -125,7 +125,7 @@ service class SslProxyServer {
    }
 
    remote function onBinaryMessage(Caller caller, byte[] data) {
-       var returnVal = caller->writeBytes(data);
+       var returnVal = caller->writeBinaryMessage(data);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -179,7 +179,7 @@ public function testSslProxySendBinary() returns Error? {
            }
        });
    byte[] binaryData = [5, 24, 56];
-   check wsClient->writeBytes(binaryData);
+   check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(0.5);
    test:assertEquals(expectedBinaryData, binaryData, msg = "Data mismatched");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -35,7 +35,7 @@ service /sslEcho on l24 {
 }
 service class SslProxy {
    *Service;
-   remote function onConnect(Caller wsEp) returns Error? {
+   remote function onOpen(Caller wsEp) returns Error? {
        AsyncClient wsClientEp = check new ("wss://localhost:21028/websocket", new sslClientService(), {
                secureSocket: {
                    trustStore: {
@@ -113,7 +113,7 @@ service /websocket on l27 {
 
 service class SslProxyServer {
    *Service;
-   remote function onConnect(Caller caller) {
+   remote function onOpen(Caller caller) {
        io:println("The Connection ID: " + caller.getConnectionId());
    }
 

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -42,13 +42,8 @@ service class SslProxy {
                        path: TRUSTSTORE_PATH,
                        password: "ballerina"
                    }
-               },
-               readyOnConnect: false
+               }
            });
-       var returnVal = wsClientEp->ready();
-       if (returnVal is Error) {
-           panic <error>returnVal;
-       }
    }
 
    remote function onTextMessage(Caller wsEp, string text) {

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -51,7 +51,7 @@ service class SslProxy {
        }
    }
 
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        var returnVal = wsEp->writeString(text);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -75,7 +75,7 @@ service class SslProxy {
 
 service class sslClientService {
    *Service;
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        var returnVal = wsEp->writeString(text);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -117,7 +117,7 @@ service class SslProxyServer {
        io:println("The Connection ID: " + caller.getConnectionId());
    }
 
-   remote function onString(Caller caller, string text) {
+   remote function onTextMessage(Caller caller, string text) {
        var err = caller->writeString(text);
        if (err is Error) {
            io:println("Error occurred when sending text message: ", err);
@@ -134,7 +134,7 @@ service class SslProxyServer {
 
 service class sslProxyCallbackService {
    *Service;
-   remote function onString(Caller wsEp, string text) {
+   remote function onTextMessage(Caller wsEp, string text) {
        proxyData = <@untainted>text;
    }
 

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -52,7 +52,7 @@ service class SslProxy {
    }
 
    remote function onTextMessage(Caller wsEp, string text) {
-       var returnVal = wsEp->writeString(text);
+       var returnVal = wsEp->writeTextMessage(text);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -76,7 +76,7 @@ service class SslProxy {
 service class sslClientService {
    *Service;
    remote function onTextMessage(Caller wsEp, string text) {
-       var returnVal = wsEp->writeString(text);
+       var returnVal = wsEp->writeTextMessage(text);
        if (returnVal is Error) {
            panic <error>returnVal;
        }
@@ -118,7 +118,7 @@ service class SslProxyServer {
    }
 
    remote function onTextMessage(Caller caller, string text) {
-       var err = caller->writeString(text);
+       var err = caller->writeTextMessage(text);
        if (err is Error) {
            io:println("Error occurred when sending text message: ", err);
        }
@@ -161,7 +161,7 @@ public function testSslProxySendText() returns Error? {
                }
            }
        });
-   check wsClient->writeString("Hi");
+   check wsClient->writeTextMessage("Hi");
    runtime:sleep(0.5);
    test:assertEquals(proxyData, "Hi", msg = "Data mismatched");
    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeoutInSeconds = 0);

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -58,7 +58,7 @@ service class SslProxy {
        }
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        var returnVal = wsEp->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -82,7 +82,7 @@ service class sslClientService {
        }
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        var returnVal = wsEp->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -124,7 +124,7 @@ service class SslProxyServer {
        }
    }
 
-   remote function onBytes(Caller caller, byte[] data) {
+   remote function onBinaryMessage(Caller caller, byte[] data) {
        var returnVal = caller->writeBytes(data);
        if (returnVal is Error) {
            panic <error>returnVal;
@@ -138,7 +138,7 @@ service class sslProxyCallbackService {
        proxyData = <@untainted>text;
    }
 
-   remote function onBytes(Caller wsEp, byte[] data) {
+   remote function onBinaryMessage(Caller wsEp, byte[] data) {
        expectedBinaryData = <@untainted>data;
    }
 

--- a/websocket-ballerina/websocket_caller.bal
+++ b/websocket-ballerina/websocket_caller.bal
@@ -43,8 +43,8 @@ public client class Caller {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeBytes(byte[] data) returns Error? {
-        return self.conn.writeBytes(data);
+    remote isolated function writeBinaryMessage(byte[] data) returns Error? {
+        return self.conn.writeBinaryMessage(data);
     }
 
     # Pings the connection. If an error occurs while sending the ping frame to the server, that frame will be lost.

--- a/websocket-ballerina/websocket_caller.bal
+++ b/websocket-ballerina/websocket_caller.bal
@@ -34,8 +34,8 @@ public client class Caller {
     #
     # + data - Data to be sent.
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeString(string data) returns Error? {
-        return self.conn.writeString(data);
+    remote isolated function writeTextMessage(string data) returns Error? {
+        return self.conn.writeTextMessage(data);
     }
 
     # Pushes binary data to the connection. If an error occurs while sending the binary message to the connection,

--- a/websocket-ballerina/websocket_client.bal
+++ b/websocket-ballerina/websocket_client.bal
@@ -76,8 +76,8 @@ public client class AsyncClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeBytes(byte[] data) returns Error? {
-        return self.conn.writeBytes(data);
+    remote isolated function writeBinaryMessage(byte[] data) returns Error? {
+        return self.conn.writeBinaryMessage(data);
     }
 
     # Pings the connection. If an error occurs while sending the ping frame to the server, that frame will be lost.

--- a/websocket-ballerina/websocket_client.bal
+++ b/websocket-ballerina/websocket_client.bal
@@ -112,14 +112,6 @@ public client class AsyncClient {
         return self.conn.close(statusCode, reason, timeoutInSeconds);
     }
 
-    # Calls when the endpoint is ready to receive messages. It can be called only once per endpoint. For the
-    # WebSocketListener, it can be called only in the `onUpgrade` or `onOpen` resources.
-    #
-    # + return - an `error` if an error occurs while checking the connection state
-    remote isolated function ready() returns Error? {
-        return self.conn.ready();
-    }
-
     # Sets a connection-related attribute.
     #
     # + key - The key, which identifies the attribute
@@ -190,7 +182,6 @@ public client class AsyncClient {
 # | subProtocols - Copied from CommonWebSocketClientConfiguration                |
 # | customHeaders - Copied from CommonWebSocketClientConfiguration               |
 # | idleTimeoutInSeconds - Copied from CommonWebSocketClientConfiguration        |
-# | readyOnConnect - Copied from CommonWebSocketClientConfiguration              |
 # | secureSocket - Copied from CommonWebSocketClientConfiguration                |
 # | maxFrameSize - Copied from CommonWebSocketClientConfiguration                |
 # | webSocketCompressionEnabled - Copied from CommonWebSocketClientConfiguration |
@@ -208,9 +199,6 @@ public type WebSocketClientConfiguration record {|
 # + customHeaders - Custom headers, which should be sent to the server
 # + idleTimeoutInSeconds - Idle timeout of the client. Upon timeout, the `onIdleTimeout` resource (if defined)
 #                          of the client service will be triggered
-# + readyOnConnect - Set to `true` if the client is ready to receive messages as soon as the connection is established.
-#                    This is set to `true` by default. If changed to `false`, the ready() function of the
-#                    `WebSocketClient` needs to be called once to start receiving messages
 # + secureSocket - SSL/TLS-related options
 # + maxFrameSize - The maximum payload size of a WebSocket frame in bytes
 #                  If this is not set, is negative, or is zero, the default frame size of 65536 will be used.
@@ -223,7 +211,6 @@ public type CommonWebSocketClientConfiguration record {|
     string[] subProtocols = [];
     map<string> customHeaders = {};
     int idleTimeoutInSeconds = -1;
-    boolean readyOnConnect = true;
     http:ClientSecureSocket? secureSocket = ();
     int maxFrameSize = 0;
     boolean webSocketCompressionEnabled = true;

--- a/websocket-ballerina/websocket_client.bal
+++ b/websocket-ballerina/websocket_client.bal
@@ -113,7 +113,7 @@ public client class AsyncClient {
     }
 
     # Calls when the endpoint is ready to receive messages. It can be called only once per endpoint. For the
-    # WebSocketListener, it can be called only in the `onUpgrade` or `onConnect` resources.
+    # WebSocketListener, it can be called only in the `onUpgrade` or `onOpen` resources.
     #
     # + return - an `error` if an error occurs while checking the connection state
     remote isolated function ready() returns Error? {

--- a/websocket-ballerina/websocket_client.bal
+++ b/websocket-ballerina/websocket_client.bal
@@ -67,8 +67,8 @@ public client class AsyncClient {
     #
     # + data - Data to be sent.
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeString(string data) returns Error? {
-        return self.conn.writeString(data);
+    remote isolated function writeTextMessage(string data) returns Error? {
+        return self.conn.writeTextMessage(data);
     }
 
     # Writes binary data to the connection. If an error occurs while sending the binary message to the connection,

--- a/websocket-ballerina/websocket_connector.bal
+++ b/websocket-ballerina/websocket_connector.bal
@@ -56,7 +56,7 @@ class WebSocketConnector {
     }
 
     # Calls when the endpoint is ready to receive messages. It can be called only once per endpoint. The
-    # WebSocketListener can be called only in the `upgrade` or `onConnect` resources.
+    # WebSocketListener can be called only in the `upgrade` or `onOpen` resources.
     #
     # + return - An `error` if an error occurs when sending
     public isolated function ready() returns Error? {

--- a/websocket-ballerina/websocket_connector.bal
+++ b/websocket-ballerina/websocket_connector.bal
@@ -34,8 +34,8 @@ class WebSocketConnector {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    public isolated function writeBytes(byte[] data) returns Error? {
-        return externWriteBytes(self, data);
+    public isolated function writeBinaryMessage(byte[] data) returns Error? {
+        return externWriteBinaryMessage(self, data);
     }
 
     # Pings the connection. If an error occurs while sending the ping frame to the connection, that frame will be lost.
@@ -106,10 +106,10 @@ isolated function externWriteTextMessage(WebSocketConnector wsConnector, string 
     'class: "org.ballerinalang.net.websocket.actions.websocketconnector.WebSocketConnector"
 } external;
 
-isolated function externWriteBytes(WebSocketConnector wsConnector, byte[] data) returns Error? =
+isolated function externWriteBinaryMessage(WebSocketConnector wsConnector, byte[] data) returns Error? =
 @java:Method {
     'class: "org.ballerinalang.net.websocket.actions.websocketconnector.WebSocketConnector",
-    name: "writeBytes"
+    name: "writeBinaryMessage"
 } external;
 
 isolated function externPing(WebSocketConnector wsConnector, byte[] data) returns Error? =

--- a/websocket-ballerina/websocket_connector.bal
+++ b/websocket-ballerina/websocket_connector.bal
@@ -25,8 +25,8 @@ class WebSocketConnector {
     #
     # + data - Data to be sent.
     # + return  - An `error` if an error occurs when sending
-    public isolated function writeString(string data) returns Error? {
-        return externWriteString(self, data);
+    public isolated function writeTextMessage(string data) returns Error? {
+        return externWriteTextMessage(self, data);
     }
 
     # Pushes binary data to the connection. If an error occurs while sending the binary message to the connection,
@@ -101,7 +101,7 @@ class WebSocketConnector {
     }
 }
 
-isolated function externWriteString(WebSocketConnector wsConnector, string text) returns Error? =
+isolated function externWriteTextMessage(WebSocketConnector wsConnector, string text) returns Error? =
 @java:Method {
     'class: "org.ballerinalang.net.websocket.actions.websocketconnector.WebSocketConnector"
 } external;

--- a/websocket-ballerina/websocket_connector.bal
+++ b/websocket-ballerina/websocket_connector.bal
@@ -55,14 +55,6 @@ class WebSocketConnector {
         return externPong(self, data);
     }
 
-    # Calls when the endpoint is ready to receive messages. It can be called only once per endpoint. The
-    # WebSocketListener can be called only in the `upgrade` or `onOpen` resources.
-    #
-    # + return - An `error` if an error occurs when sending
-    public isolated function ready() returns Error? {
-        return externReady(self);
-    }
-
     # Reads text data from the websocket connection.
     #
     # + return  - The text message or an `error` if an error occurs when sending

--- a/websocket-ballerina/websocket_connector.bal
+++ b/websocket-ballerina/websocket_connector.bal
@@ -66,8 +66,8 @@ class WebSocketConnector {
     # Reads text data from the websocket connection.
     #
     # + return  - The text message or an `error` if an error occurs when sending
-    public isolated function readString() returns string|Error {
-        return externReadString(self);
+    public isolated function readTextMessage() returns string|Error {
+        return externReadTextMessage(self);
     }
 
     # Reads binary data from the websocket connection.
@@ -135,7 +135,7 @@ isolated function externReady(WebSocketConnector wsConnector) returns Error? = @
     name: "ready"
 } external;
 
-isolated function externReadString(WebSocketConnector wsConnector) returns string|Error =
+isolated function externReadTextMessage(WebSocketConnector wsConnector) returns string|Error =
 @java:Method {
     'class: "org.ballerinalang.net.websocket.actions.websocketconnector.WebSocketConnector"
 } external;

--- a/websocket-ballerina/websocket_connector.bal
+++ b/websocket-ballerina/websocket_connector.bal
@@ -73,8 +73,8 @@ class WebSocketConnector {
     # Reads binary data from the websocket connection.
     #
     # + return  - The binary message or an `error` if an error occurs when sending
-    public isolated function readBytes() returns byte[]|Error {
-        return externReadBytes(self);
+    public isolated function readBinaryMessage() returns byte[]|Error {
+        return externReadBinaryMessage(self);
     }
 
     # Closes the connection.
@@ -140,7 +140,7 @@ isolated function externReadTextMessage(WebSocketConnector wsConnector) returns 
     'class: "org.ballerinalang.net.websocket.actions.websocketconnector.WebSocketConnector"
 } external;
 
-isolated function externReadBytes(WebSocketConnector wsConnector) returns byte[]|Error =
+isolated function externReadBinaryMessage(WebSocketConnector wsConnector) returns byte[]|Error =
 @java:Method {
     'class: "org.ballerinalang.net.websocket.actions.websocketconnector.WebSocketConnector"
 } external;

--- a/websocket-ballerina/websocket_failover_client.bal
+++ b/websocket-ballerina/websocket_failover_client.bal
@@ -91,14 +91,6 @@ public client class WebSocketFailoverClient {
         return self.conn.close(statusCode, reason, timeoutInSeconds);
     }
 
-    # Calls when the endpoint is ready to receive messages. It can be called only once per endpoint. For the
-    # WebSocketListener, it can be called only in the `upgrade` or `onOpen` resources.
-    #
-    # + return - An `error` if an error occurs while checking the connection state
-    remote isolated function ready() returns Error? {
-        return self.conn.ready();
-    }
-
     # Sets a connection-related attribute.
     #
     # + key - The key to identify the attribute
@@ -167,7 +159,6 @@ public client class WebSocketFailoverClient {
 # | subProtocols - Copied from CommonWebSocketClientConfiguration                |
 # | customHeaders - Copied from CommonWebSocketClientConfiguration               |
 # | idleTimeoutInSeconds - Copied from CommonWebSocketClientConfiguration        |
-# | readyOnConnect - Copied from CommonWebSocketClientConfiguration              |
 # | secureSocket - Copied from CommonWebSocketClientConfiguration                |
 # | maxFrameSize - Copied from CommonWebSocketClientConfiguration                |
 # | webSocketCompressionEnabled - Copied from CommonWebSocketClientConfiguration |

--- a/websocket-ballerina/websocket_failover_client.bal
+++ b/websocket-ballerina/websocket_failover_client.bal
@@ -55,8 +55,8 @@ public client class WebSocketFailoverClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeBytes(byte[] data) returns Error? {
-        return self.conn.writeBytes(data);
+    remote isolated function writeBinaryMessage(byte[] data) returns Error? {
+        return self.conn.writeBinaryMessage(data);
     }
 
     # Pings the connection. If an error occurs while sending the ping frame to the connection, that frame will be lost.

--- a/websocket-ballerina/websocket_failover_client.bal
+++ b/websocket-ballerina/websocket_failover_client.bal
@@ -46,8 +46,8 @@ public client class WebSocketFailoverClient {
     #
     # + data - Data to be sent. If it is a byte[], it is converted to a UTF-8 string for sending
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeString(string data) returns Error? {
-        return self.conn.writeString(data);
+    remote isolated function writeTextMessage(string data) returns Error? {
+        return self.conn.writeTextMessage(data);
     }
 
     # Pushes binary data to the connection. If an error occurs while sending the binary message to the connection,

--- a/websocket-ballerina/websocket_failover_client.bal
+++ b/websocket-ballerina/websocket_failover_client.bal
@@ -92,7 +92,7 @@ public client class WebSocketFailoverClient {
     }
 
     # Calls when the endpoint is ready to receive messages. It can be called only once per endpoint. For the
-    # WebSocketListener, it can be called only in the `upgrade` or `onConnect` resources.
+    # WebSocketListener, it can be called only in the `upgrade` or `onOpen` resources.
     #
     # + return - An `error` if an error occurs while checking the connection state
     remote isolated function ready() returns Error? {

--- a/websocket-ballerina/websocket_sync_client.bal
+++ b/websocket-ballerina/websocket_sync_client.bal
@@ -168,8 +168,8 @@ public client class SyncClient {
     # Reads the texts in a synchronous manner
     #
     # + return  - The text data sent by the server or an `error` if an error occurs when sending
-    remote isolated function readString() returns string|Error {
-        return self.conn.readString();
+    remote isolated function readTextMessage() returns string|Error {
+        return self.conn.readTextMessage();
     }
 
     # Reads the binary data in a synchronous manner

--- a/websocket-ballerina/websocket_sync_client.bal
+++ b/websocket-ballerina/websocket_sync_client.bal
@@ -70,8 +70,8 @@ public client class SyncClient {
     #
     # + data - Binary data to be sent
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeBytes(byte[] data) returns Error? {
-        return self.conn.writeBytes(data);
+    remote isolated function writeBinaryMessage(byte[] data) returns Error? {
+        return self.conn.writeBinaryMessage(data);
     }
 
     # Pings the connection. If an error occurs while sending the ping frame to the server, that frame will be lost.

--- a/websocket-ballerina/websocket_sync_client.bal
+++ b/websocket-ballerina/websocket_sync_client.bal
@@ -175,8 +175,8 @@ public client class SyncClient {
     # Reads the binary data in a synchronous manner
     #
     # + return  - The binary data sent by the server or an `error` if an error occurs when sending
-    remote isolated function readBytes() returns byte[]|Error {
-        return self.conn.readBytes();
+    remote isolated function readBinaryMessage() returns byte[]|Error {
+        return self.conn.readBinaryMessage();
     }
 }
 

--- a/websocket-ballerina/websocket_sync_client.bal
+++ b/websocket-ballerina/websocket_sync_client.bal
@@ -61,8 +61,8 @@ public client class SyncClient {
     #
     # + data - Data to be sent.
     # + return  - An `error` if an error occurs when sending
-    remote isolated function writeString(string data) returns Error? {
-        return self.conn.writeString(data);
+    remote isolated function writeTextMessage(string data) returns Error? {
+        return self.conn.writeTextMessage(data);
     }
 
     # Writes binary data to the connection. If an error occurs while sending the binary message to the connection,

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -58,7 +58,7 @@ public class WebSocketConstants {
     public static final BString ANNOTATION_ATTR_IDLE_TIMEOUT = StringUtils.fromString("idleTimeoutInSeconds");
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");
 
-    public static final String RESOURCE_NAME_ON_CONNECT = "onConnect";
+    public static final String RESOURCE_NAME_ON_CONNECT = "onOpen";
     public static final String RESOURCE_NAME_ON_STRING = "onTextMessage";
     public static final String RESOURCE_NAME_ON_BINARY = "onBinaryMessage";
     public static final String RESOURCE_NAME_ON_PING = "onPing";

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -60,7 +60,7 @@ public class WebSocketConstants {
 
     public static final String RESOURCE_NAME_ON_CONNECT = "onConnect";
     public static final String RESOURCE_NAME_ON_STRING = "onTextMessage";
-    public static final String RESOURCE_NAME_ON_BINARY = "onBytes";
+    public static final String RESOURCE_NAME_ON_BINARY = "onBinaryMessage";
     public static final String RESOURCE_NAME_ON_PING = "onPing";
     public static final String RESOURCE_NAME_ON_PONG = "onPong";
     public static final String RESOURCE_NAME_ON_CLOSE = "onClose";

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -59,7 +59,7 @@ public class WebSocketConstants {
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");
 
     public static final String RESOURCE_NAME_ON_CONNECT = "onConnect";
-    public static final String RESOURCE_NAME_ON_STRING = "onString";
+    public static final String RESOURCE_NAME_ON_STRING = "onTextMessage";
     public static final String RESOURCE_NAME_ON_BINARY = "onBytes";
     public static final String RESOURCE_NAME_ON_PING = "onPing";
     public static final String RESOURCE_NAME_ON_PONG = "onPong";

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -69,7 +69,7 @@ public class WebSocketConstants {
     public static final String RESOURCE_NAME_CLOSE = "close";
     public static final String RESOURCE_NAME_PING = "ping";
     public static final String RESOURCE_NAME_PONG = "pong";
-    public static final String WRITE_BYTES = "writeBytes";
+    public static final String WRITE_BYTES = "writeBinaryMessage";
     public static final String WRITE_STRING = "writeTextMessage";
     public static final String RESOURCE_NAME_READY = "ready";
     public static final String RESOURCE_NAME_UPGRADE = "onUpgrade";

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -70,7 +70,7 @@ public class WebSocketConstants {
     public static final String RESOURCE_NAME_PING = "ping";
     public static final String RESOURCE_NAME_PONG = "pong";
     public static final String WRITE_BYTES = "writeBytes";
-    public static final String WRITE_STRING = "writeString";
+    public static final String WRITE_STRING = "writeTextMessage";
     public static final String RESOURCE_NAME_READY = "ready";
     public static final String RESOURCE_NAME_UPGRADE = "onUpgrade";
 

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -58,9 +58,9 @@ public class WebSocketConstants {
     public static final BString ANNOTATION_ATTR_IDLE_TIMEOUT = StringUtils.fromString("idleTimeoutInSeconds");
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");
 
-    public static final String RESOURCE_NAME_ON_CONNECT = "onOpen";
-    public static final String RESOURCE_NAME_ON_STRING = "onTextMessage";
-    public static final String RESOURCE_NAME_ON_BINARY = "onBinaryMessage";
+    public static final String RESOURCE_NAME_ON_OPEN = "onOpen";
+    public static final String RESOURCE_NAME_ON_TEXT_MESSAGE = "onTextMessage";
+    public static final String RESOURCE_NAME_ON_BINARY_MESSAGE = "onBinaryMessage";
     public static final String RESOURCE_NAME_ON_PING = "onPing";
     public static final String RESOURCE_NAME_ON_PONG = "onPong";
     public static final String RESOURCE_NAME_ON_CLOSE = "onClose";
@@ -69,8 +69,8 @@ public class WebSocketConstants {
     public static final String RESOURCE_NAME_CLOSE = "close";
     public static final String RESOURCE_NAME_PING = "ping";
     public static final String RESOURCE_NAME_PONG = "pong";
-    public static final String WRITE_BYTES = "writeBinaryMessage";
-    public static final String WRITE_STRING = "writeTextMessage";
+    public static final String WRITE_BINARY_MESSAGE = "writeBinaryMessage";
+    public static final String WRITE_TEXT_MESSAGE = "writeTextMessage";
     public static final String RESOURCE_NAME_READY = "ready";
     public static final String RESOURCE_NAME_UPGRADE = "onUpgrade";
 
@@ -146,11 +146,13 @@ public class WebSocketConstants {
 
     // Strand meta data
     public static final StrandMetadata ON_OPEN_METADATA =
-            new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION, RESOURCE_NAME_ON_CONNECT);
+            new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION, RESOURCE_NAME_ON_OPEN);
     public static final StrandMetadata ON_TEXT_METADATA =
-            new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION, RESOURCE_NAME_ON_STRING);
+            new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION,
+                    RESOURCE_NAME_ON_TEXT_MESSAGE);
     public static final StrandMetadata ON_BINARY_METADATA =
-            new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION, RESOURCE_NAME_ON_BINARY);
+            new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION,
+                    RESOURCE_NAME_ON_BINARY_MESSAGE);
     public static final StrandMetadata ON_PING_METADATA =
             new StrandMetadata(BALLERINA_ORG, PACKAGE_WEBSOCKET, WEBSOCKET_MODULE_VERSION, RESOURCE_NAME_ON_PING);
     public static final StrandMetadata ON_PONG_METADATA =

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketResourceDispatcher.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketResourceDispatcher.java
@@ -82,14 +82,14 @@ import static org.ballerinalang.net.websocket.WebSocketConstants.ON_TEXT_METADAT
 import static org.ballerinalang.net.websocket.WebSocketConstants.ON_TIMEOUT_METADATA;
 import static org.ballerinalang.net.websocket.WebSocketConstants.ON_UPGRADE_METADATA;
 import static org.ballerinalang.net.websocket.WebSocketConstants.PARAM_TYPE_STRING;
-import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_BINARY;
+import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_BINARY_MESSAGE;
 import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_CLOSE;
-import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_CONNECT;
 import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_ERROR;
 import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_IDLE_TIMEOUT;
+import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_OPEN;
 import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_PING;
 import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_PONG;
-import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_STRING;
+import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_TEXT_MESSAGE;
 
 /**
  * {@code WebSocketDispatcher} This is the web socket request dispatcher implementation which finds best matching
@@ -192,7 +192,7 @@ public class WebSocketResourceDispatcher {
                 .getType())).getMethods();
         BObject balService = (BObject) dispatchingService;
         for (MethodType remoteFunc : remoteFunctions) {
-            if (remoteFunc.getName().equals(RESOURCE_NAME_ON_CONNECT)) {
+            if (remoteFunc.getName().equals(RESOURCE_NAME_ON_OPEN)) {
                 onOpenResource = remoteFunc;
                 break;
             }
@@ -225,10 +225,10 @@ public class WebSocketResourceDispatcher {
                 WebSocketUtil.closeDuringUnexpectedCondition(webSocketConnection);
                 WebSocketObservabilityUtil
                         .observeError(connectionInfo, WebSocketObservabilityConstants.ERROR_TYPE_RESOURCE_INVOCATION,
-                                RESOURCE_NAME_ON_CONNECT, error.getMessage());
+                                RESOURCE_NAME_ON_OPEN, error.getMessage());
             }
         };
-        executeResource(wsService, balService, onOpenCallback, bValues, connectionInfo, RESOURCE_NAME_ON_CONNECT,
+        executeResource(wsService, balService, onOpenCallback, bValues, connectionInfo, RESOURCE_NAME_ON_OPEN,
                 ON_OPEN_METADATA);
     }
 
@@ -247,14 +247,14 @@ public class WebSocketResourceDispatcher {
                 MethodType[] remoteFunctions = ((ServiceType) (((BValue) dispatchingService).getType()))
                         .getMethods();
                 for (MethodType remoteFunc : remoteFunctions) {
-                    if (remoteFunc.getName().equals(RESOURCE_NAME_ON_STRING)) {
+                    if (remoteFunc.getName().equals(RESOURCE_NAME_ON_TEXT_MESSAGE)) {
                         onTextMessageResource = remoteFunc;
                         break;
                     }
                 }
             } else {
                 balservice = wsService.getBalService();
-                onTextMessageResource = wsService.getResourceByName(RESOURCE_NAME_ON_STRING);
+                onTextMessageResource = wsService.getResourceByName(RESOURCE_NAME_ON_TEXT_MESSAGE);
             }
             if (onTextMessageResource == null) {
                 webSocketConnection.readNextFrame();
@@ -276,8 +276,8 @@ public class WebSocketResourceDispatcher {
                 bValues[2] = StringUtils.fromString(stringAggregator.getAggregateString());
                 bValues[3] = true;
                 executeResource(wsService, balservice,
-                        new WebSocketResourceCallback(connectionInfo, RESOURCE_NAME_ON_STRING), bValues, connectionInfo,
-                        RESOURCE_NAME_ON_STRING, ON_TEXT_METADATA);
+                        new WebSocketResourceCallback(connectionInfo, RESOURCE_NAME_ON_TEXT_MESSAGE), bValues,
+                        connectionInfo, RESOURCE_NAME_ON_TEXT_MESSAGE, ON_TEXT_METADATA);
                 stringAggregator.resetAggregateString();
             } else {
                 stringAggregator.appendAggregateString(textMessage.getText());
@@ -363,14 +363,14 @@ public class WebSocketResourceDispatcher {
                 MethodType[] remoteFunctions = ((ServiceType) (((BValue) dispatchingService).getType()))
                         .getMethods();
                 for (MethodType remoteFunc : remoteFunctions) {
-                    if (remoteFunc.getName().equals(RESOURCE_NAME_ON_BINARY)) {
+                    if (remoteFunc.getName().equals(RESOURCE_NAME_ON_BINARY_MESSAGE)) {
                         onBinaryMessageResource = remoteFunc;
                         break;
                     }
                 }
             } else {
                 balservice = wsService.getBalService();
-                onBinaryMessageResource = wsService.getResourceByName(RESOURCE_NAME_ON_BINARY);
+                onBinaryMessageResource = wsService.getResourceByName(RESOURCE_NAME_ON_BINARY_MESSAGE);
             }
             if (onBinaryMessageResource == null) {
                 webSocketConnection.readNextFrame();
@@ -388,8 +388,8 @@ public class WebSocketResourceDispatcher {
                 bValues[2] = ValueCreator.createArrayValue(byteAggregator.getAggregateByteArr());
                 bValues[3] = true;
                 executeResource(wsService, balservice, new WebSocketResourceCallback(
-                                connectionInfo, RESOURCE_NAME_ON_BINARY), bValues, connectionInfo,
-                        RESOURCE_NAME_ON_BINARY, ON_BINARY_METADATA);
+                                connectionInfo, RESOURCE_NAME_ON_BINARY_MESSAGE), bValues, connectionInfo,
+                        RESOURCE_NAME_ON_BINARY_MESSAGE, ON_BINARY_METADATA);
                 byteAggregator.resetAggregateByteArr();
             } else {
                 byteAggregator.appendAggregateArr(binaryMessage.getByteArray());

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketUtil.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketUtil.java
@@ -340,8 +340,7 @@ public class WebSocketUtil {
      */
     public static void establishWebSocketConnection(WebSocketClientConnector clientConnector,
             BObject webSocketClient, WebSocketService wsService) {
-        boolean readyOnConnect = webSocketClient.getMapValue(CLIENT_ENDPOINT_CONFIG).getBooleanValue(
-                WebSocketConstants.CLIENT_READY_ON_CONNECT);
+        boolean readyOnConnect = true;
         ClientHandshakeFuture handshakeFuture = clientConnector.connect();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         setListenersToHandshakeFuture(handshakeFuture, webSocketClient, wsService, countDownLatch, readyOnConnect);

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
@@ -44,7 +44,7 @@ import java.util.concurrent.SynchronousQueue;
 public class WebSocketConnector {
     private static final Logger log = LoggerFactory.getLogger(WebSocketConnector.class);
 
-    public static Object externWriteString(Environment env, BObject wsConnection, BString text) {
+    public static Object externWriteTextMessage(Environment env, BObject wsConnection, BString text) {
         Future balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
@@ -49,7 +49,7 @@ public class WebSocketConnector {
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(env, connectionInfo,
-                WebSocketConstants.WRITE_STRING);
+                WebSocketConstants.WRITE_TEXT_MESSAGE);
         try {
             ChannelFuture future = connectionInfo.getWebSocketConnection().pushText(text.getValue(), true);
             WebSocketUtil.handleWebSocketCallback(balFuture, future, log, connectionInfo);
@@ -71,7 +71,7 @@ public class WebSocketConnector {
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         WebSocketObservabilityUtil.observeResourceInvocation(env, connectionInfo,
-                WebSocketConstants.WRITE_BYTES);
+                WebSocketConstants.WRITE_BINARY_MESSAGE);
         try {
             ChannelFuture webSocketChannelFuture = connectionInfo.getWebSocketConnection().pushBinary(
                     ByteBuffer.wrap(binaryData.getBytes()), true);

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
@@ -66,7 +66,7 @@ public class WebSocketConnector {
         return null;
     }
 
-    public static Object writeBytes(Environment env, BObject wsConnection, BArray binaryData) {
+    public static Object writeBinaryMessage(Environment env, BObject wsConnection, BArray binaryData) {
         Future balFuture = env.markAsync();
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
@@ -157,7 +157,7 @@ public class WebSocketConnector {
         }
     }
 
-    public static Object externReadBytes(Environment env, BObject wsConnection) {
+    public static Object externReadBinaryMessage(Environment env, BObject wsConnection) {
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         try {

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/actions/websocketconnector/WebSocketConnector.java
@@ -133,7 +133,7 @@ public class WebSocketConnector {
         return null;
     }
 
-    public static Object externReadString(Environment env, BObject wsConnection) {
+    public static Object externReadTextMessage(Environment env, BObject wsConnection) {
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
         try {

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/listener/WebSocketHandshakeListener.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/listener/WebSocketHandshakeListener.java
@@ -40,7 +40,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.ballerinalang.net.http.HttpConstants.CLIENT_ENDPOINT_CONFIG;
 import static org.ballerinalang.net.websocket.WebSocketConstants.ON_OPEN_METADATA;
-import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_CONNECT;
+import static org.ballerinalang.net.websocket.WebSocketConstants.RESOURCE_NAME_ON_OPEN;
 import static org.ballerinalang.net.websocket.WebSocketConstants.SYNC_CLIENT;
 
 /**
@@ -94,7 +94,7 @@ public class WebSocketHandshakeListener implements ExtendedHandshakeListener {
     private static void dispatchClientOnOpen(WebSocketConnection webSocketConnection,
             WebSocketConnectionInfo connectionInfo, WebSocketService wsService) {
         BObject dispatchingService = wsService.getBalService();
-        MethodType onOpenResource = wsService.getResourceByName(RESOURCE_NAME_ON_CONNECT);
+        MethodType onOpenResource = wsService.getResourceByName(RESOURCE_NAME_ON_OPEN);
         if (onOpenResource != null) {
             Type[] parameterTypes = onOpenResource.getParameterTypes();
             Object[] bValues = new Object[parameterTypes.length * 2];
@@ -112,7 +112,7 @@ public class WebSocketHandshakeListener implements ExtendedHandshakeListener {
                 }
             };
             wsService.getRuntime()
-                    .invokeMethodAsync(dispatchingService, RESOURCE_NAME_ON_CONNECT, null, ON_OPEN_METADATA,
+                    .invokeMethodAsync(dispatchingService, RESOURCE_NAME_ON_OPEN, null, ON_OPEN_METADATA,
                             onOpenCallback, bValues);
         }
     }

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/server/WebSocketConnectionInfo.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/server/WebSocketConnectionInfo.java
@@ -108,7 +108,7 @@ public class WebSocketConnectionInfo {
     }
 
     /**
-     * A string aggregator to handle string aggregation for data binding during onString resource dispatching. The
+     * A string aggregator to handle string aggregation for data binding during onTextMessage resource dispatching. The
      * aggregation is done in the ConnectionInfo class because the strings specific to a particular connection needs to
      * be aggregated.
      */


### PR DESCRIPTION
## Purpose

- Rename `onString` to `onTextMessage`
- Rename `onBytes` to `onBinaryMessage`
- Rename `readString` to `readTextMessage`
- Rename `readBytes` to `readBinaryMessage`
- Rename `writeString` to `writeTextMessage`
- Rename `writeBytes` to `writeBinaryMessage`
- Rename `onConnect` to `onOpen`
- Remove readyOnConnect configuration
- Remove read() client action