### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -41,6 +41,8 @@ jobs:
           name: Code Coverage JSON
           path: websocket-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,8 @@ jobs:
           name: Code Coverage JSON
           path: websocket-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
 
   windows-build:
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+fixes:
+  - "ballerina/websocket/*/::websocket-ballerina/"
+
+ignore:
+  - "**/tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: no
+
 fixes:
   - "ballerina/websocket/*/::websocket-ballerina/"
 


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `websocket` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` and `Build Master` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on push or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` adds comments to any PR made based on the code coverage changes between commits

## Test environment
- Ubuntu 20.04

## Related Issues 
- [#28642](https://github.com/ballerina-platform/ballerina-lang/issues/28642)
