### PR TITLE
Rename ListenerConfiguration and ClientConfiguration

### DIFF
--- a/websocket-ballerina/auth_utils.bal
+++ b/websocket-ballerina/auth_utils.bal
@@ -20,7 +20,7 @@ import ballerina/log;
 import ballerina/oauth2;
 
 // Call relevant auth handling function based on the provided configurations
-isolated function initClientAuth(ClientConfiguration config) returns AuthError? {
+isolated function initClientAuth(ClientOptions config) returns AuthError? {
     ClientAuthConfig? authConfig = config?.auth;
     if (authConfig is ()) {
        return;
@@ -35,7 +35,7 @@ isolated function initClientAuth(ClientConfiguration config) returns AuthError? 
     }
 }
 
-isolated function handleClientSelfSignedJwtAuth(JwtIssuerConfig config, ClientConfiguration clientConfig)
+isolated function handleClientSelfSignedJwtAuth(JwtIssuerConfig config, ClientOptions clientConfig)
                      returns AuthError? {
     jwt:ClientSelfSignedJwtAuthProvider provider = new(config);
     string|jwt:Error jwtToken = provider.generateToken();
@@ -46,7 +46,7 @@ isolated function handleClientSelfSignedJwtAuth(JwtIssuerConfig config, ClientCo
     }
 }
 
-isolated function handleClientBasicAuth(CredentialsConfig config, ClientConfiguration clientConfig)
+isolated function handleClientBasicAuth(CredentialsConfig config, ClientOptions clientConfig)
                        returns AuthError? {
     auth:ClientBasicAuthProvider provider = new(config);
     string|auth:Error basicAuthToken = provider.generateToken();
@@ -57,11 +57,11 @@ isolated function handleClientBasicAuth(CredentialsConfig config, ClientConfigur
     }
 }
 
-isolated function handleClientBearerTokenAuth(BearerTokenConfig config, ClientConfiguration clientConfig) {
+isolated function handleClientBearerTokenAuth(BearerTokenConfig config, ClientOptions clientConfig) {
     setAuthHeader(clientConfig, AUTH_SCHEME_BEARER, config.token);
 }
 
-isolated function handleClientOAuth2(OAuth2GrantConfig config, ClientConfiguration clientConfig)
+isolated function handleClientOAuth2(OAuth2GrantConfig config, ClientOptions clientConfig)
                         returns AuthError? {
     oauth2:ClientOAuth2Provider provider = new(config);
     string|oauth2:Error oauthToken = provider.generateToken();
@@ -72,7 +72,7 @@ isolated function handleClientOAuth2(OAuth2GrantConfig config, ClientConfigurati
     }
 }
 
-isolated function setAuthHeader(ClientConfiguration clientConfig, string authScheme, string token) {
+isolated function setAuthHeader(ClientOptions clientConfig, string authScheme, string token) {
     map<string> headers = clientConfig[CUSTOM_HEADERS];
     headers[AUTH_HEADER] = authScheme + " " + token;
     clientConfig[CUSTOM_HEADERS] = headers;

--- a/websocket-ballerina/service_endpoint.bal
+++ b/websocket-ballerina/service_endpoint.bal
@@ -25,7 +25,7 @@ import ballerina/http;
 public class Listener {
 
     private int port = 0;
-    private ListenerConfiguration config = {};
+    private ListenerOptions config = {};
     private string instanceId;
     private http:Listener? httpListener = ();
 
@@ -73,9 +73,9 @@ public class Listener {
     #
     # + port - Listening port of the websocket service listener
     # + config - Configurations for the websocket service listener
-    public isolated function init(int|http:Listener 'listener, *ListenerConfiguration config) returns Error? {
+    public isolated function init(int|http:Listener 'listener, *ListenerOptions options) returns Error? {
         self.instanceId = uuid();
-        self.config = config;
+        self.config = options;
         if ('listener is http:Listener) {
            self.httpListener = 'listener;
         } else {
@@ -174,7 +174,7 @@ public type Local record {|
 # + server - The server name which should appear as a response header
 # + webSocketCompressionEnabled - Enable support for compression in WebSocket
 # + requestLimits - Configurations associated with inbound request size limits
-public type ListenerConfiguration record {|
+public type ListenerOptions record {|
     string host = "0.0.0.0";
     ListenerHttp1Settings http1Settings = {};
     ListenerSecureSocket secureSocket?;

--- a/websocket-ballerina/tests/basic_auth_sync_client.bal
+++ b/websocket-ballerina/tests/basic_auth_sync_client.bal
@@ -42,7 +42,7 @@ service class WsService49 {
 
 @test:Config {}
 public function testSyncBasicAuth() returns Error? {
-    Client wsClient = check new("ws://localhost:21318/basicAuthSyncService/", config = {
+    Client wsClient = check new("ws://localhost:21318/basicAuthSyncService/", options = {
             auth: {
                 username: "alice2",
                 password: "1234"

--- a/websocket-ballerina/tests/bearer_token_sync_client.bal
+++ b/websocket-ballerina/tests/bearer_token_sync_client.bal
@@ -41,7 +41,7 @@ service class WsService54 {
 
 @test:Config {}
 public function testSyncBearerToken() returns Error? {
-    Client wsClient = check new("ws://localhost:21324/bearerTokenSyncService/", config = {
+    Client wsClient = check new("ws://localhost:21324/bearerTokenSyncService/", options = {
             auth: {
               token: "JlbmMiOiJBMTI4Q0JDLUhTMjU2Inikn"
             }

--- a/websocket-ballerina/tests/cookie_sync_client_test.bal
+++ b/websocket-ballerina/tests/cookie_sync_client_test.bal
@@ -47,14 +47,14 @@ service class WsService46 {
 http:Cookie cookie = new ("username", "name");
 http:Cookie[] httpCookies = [cookie];
 
-ClientConfiguration clientConf = {
+ClientOptions clientConf = {
    cookies: httpCookies
 };
 
 // Tests string support for sending cookies from Sync client
 @test:Config {}
 public function testSendCookieWithSyncClient() returns error? {
-   Client wsClient = check new("ws://localhost:21316/testCookieSync/", config = clientConf);
+   Client wsClient = check new("ws://localhost:21316/testCookieSync/", options = clientConf);
    var resp = wsClient.getHttpResponse();
    if (resp is http:Response) {
       http:Cookie[] respCookies = resp.getCookies();

--- a/websocket-ballerina/tests/jwt_auth_sync_client.bal
+++ b/websocket-ballerina/tests/jwt_auth_sync_client.bal
@@ -59,7 +59,7 @@ service class WsService51 {
 
 @test:Config {}
 public function testSyncJwtAuth() returns Error? {
-    Client wsClient = check new("ws://localhost:21320/jwtSyncAuthService/", config = {
+    Client wsClient = check new("ws://localhost:21320/jwtSyncAuthService/", options = {
             auth: {
                     username: "wso2",
                     issuer: "ballerina",

--- a/websocket-ballerina/tests/sync_client_idle_timeout.bal
+++ b/websocket-ballerina/tests/sync_client_idle_timeout.bal
@@ -42,7 +42,7 @@ service class OnIdleTimeoutService {
 // to check if the idle state handler gets reset.
 @test:Config {}
 public function testSyncIdleTimeOutError() returns Error? {
-    Client wsClient = check new("ws://localhost:21056/onIdleTimeoutService", config = {readTimeout: 2});
+    Client wsClient = check new("ws://localhost:21056/onIdleTimeoutService", options = {readTimeout: 2});
     @strand {
         thread:"any"
     }

--- a/websocket-ballerina/tests/sync_client_oauth2_test.bal
+++ b/websocket-ballerina/tests/sync_client_oauth2_test.bal
@@ -90,7 +90,7 @@ OAuth2DirectTokenConfig config3 = {
 
 @test:Config {}
 public function testOAuth2ClientCredentialsGrant() returns Error? {
-    Client wsClient = check new("ws://localhost:21325/oauthService/", config = {auth: config1});
+    Client wsClient = check new("ws://localhost:21325/oauthService/", options = {auth: config1});
     runtime:sleep(0.5);
     test:assertEquals(oauthHeader, "Bearer 2YotnFZFEjr1zCsicMWpAA");
     error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeout = 0);
@@ -98,7 +98,7 @@ public function testOAuth2ClientCredentialsGrant() returns Error? {
 
 @test:Config {}
 public function testOAuth2PasswordGrant() returns Error? {
-    Client wsClient = check new("ws://localhost:21325/oauthService/", config = {auth: config2});
+    Client wsClient = check new("ws://localhost:21325/oauthService/", options = {auth: config2});
     runtime:sleep(0.5);
     test:assertEquals(oauthHeader, "Bearer 2YotnFZFEjr1zCsicMWpAA");
     error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeout = 0);
@@ -106,7 +106,7 @@ public function testOAuth2PasswordGrant() returns Error? {
 
 @test:Config {}
 public function testOAuth2DirectToken() returns Error? {
-    Client wsClient = check new("ws://localhost:21325/oauthService/", config = {auth: config3});
+    Client wsClient = check new("ws://localhost:21325/oauthService/", options = {auth: config3});
     runtime:sleep(0.5);
     test:assertEquals(oauthHeader, "Bearer 2YotnFZFEjr1zCsicMWpAA");
     error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeout = 0);

--- a/websocket-ballerina/tests/sync_client_onError.bal
+++ b/websocket-ballerina/tests/sync_client_onError.bal
@@ -40,7 +40,7 @@ service class WsServiceSyncError {
 // Tests the corrupted frame error returned from readTextMessage
 @test:Config {}
 public function testSyncClientError() returns Error? {
-    Client wsClient = check new("ws://localhost:21055/onErrorText", config = {maxFrameSize: 1});
+    Client wsClient = check new("ws://localhost:21055/onErrorText", options = {maxFrameSize: 1});
     @strand {
         thread:"any"
     }

--- a/websocket-ballerina/tests/sync_client_ping_pong.bal
+++ b/websocket-ballerina/tests/sync_client_ping_pong.bal
@@ -75,7 +75,7 @@ service class clientPingPongCallbackService {
 // Ping messages are dispatched to the registered callback service.
 @test:Config {}
 public function testSyncClientPingPong() returns Error? {
-    Client wsClient = check new("ws://localhost:21057/pingpong", config = {pingPongHandler : new clientPingPongCallbackService()});
+    Client wsClient = check new("ws://localhost:21057/pingpong", options = {pingPongHandler : new clientPingPongCallbackService()});
     @strand {
         thread:"any"
     }

--- a/websocket-ballerina/tests/sync_client_send_binary_data_chunks_test.bal
+++ b/websocket-ballerina/tests/sync_client_send_binary_data_chunks_test.bal
@@ -37,7 +37,7 @@ service class WsService41 {
 // Tests writing binary data as continuation frames chunked by the given maxFrameSize using the sync client.
 @test:Config {}
 public function testChunkBinaryDataSync() returns Error? {
-   Client wsClient = check new("ws://localhost:21311/onBinaryDataSync/", config = {maxFrameSize: 1});
+   Client wsClient = check new("ws://localhost:21311/onBinaryDataSync/", options = {maxFrameSize: 1});
    byte[] binaryData = [5, 24, 56];
    check wsClient->writeBinaryMessage(binaryData);
    runtime:sleep(5);

--- a/websocket-ballerina/tests/sync_client_send_text_data_chunk_test.bal
+++ b/websocket-ballerina/tests/sync_client_send_text_data_chunk_test.bal
@@ -37,7 +37,7 @@ service class WsService42 {
 // Tests writing text data as continuation frames chunked by the given maxFrameSize using sync client.
 @test:Config {}
 public function testSendTextDataChunkSync() returns Error? {
-   Client wsClient = check new("ws://localhost:21312/onTextDataSync/", config = {maxFrameSize: 1});
+   Client wsClient = check new("ws://localhost:21312/onTextDataSync/", options = {maxFrameSize: 1});
    string textData = "text data";
    check wsClient->writeTextMessage(textData);
    runtime:sleep(5);

--- a/websocket-ballerina/tests/sync_client_ssl_error.bal
+++ b/websocket-ballerina/tests/sync_client_ssl_error.bal
@@ -39,7 +39,7 @@ service class SyncSslErrorService {
 // Tests the Ssl error returned when creating the sync client
 @test:Config {}
 public function testSyncClientSslError() {
-    Client|Error wsClient = new("wss://localhost:21058/sslTest", config = {
+    Client|Error wsClient = new("wss://localhost:21058/sslTest", options = {
                        secureSocket: {
                            cert: {
                                path: "tests/certsAndKeys/ballerinaTruststore.p12",

--- a/websocket-ballerina/tests/sync_client_ssl_test.bal
+++ b/websocket-ballerina/tests/sync_client_ssl_test.bal
@@ -48,7 +48,7 @@ service class SyncSslService {
 // Tests the successful connection of sync client over SSL
 @test:Config {}
 public function testSyncClientSsl() returns Error? {
-    Client wsClient = check new("wss://localhost:21059/sslTest", config = {
+    Client wsClient = check new("wss://localhost:21059/sslTest", options = {
                        secureSocket: {
                            cert: {
                                path: "tests/certsAndKeys/ballerinaTruststore.p12",

--- a/websocket-ballerina/tests/websocket_client_exceptions.bal
+++ b/websocket-ballerina/tests/websocket_client_exceptions.bal
@@ -20,7 +20,7 @@ import ballerina/io;
 
 string errMessage = "";
 
-ClientConfiguration config = {subProtocols: ["xml"]};
+ClientOptions config = {subProtocols: ["xml"]};
 
 service class errorResourceService {
    remote function onError(Caller clientCaller, error err) {
@@ -77,7 +77,7 @@ service class ErrorServer {
 // Connection refused IO error.
 @test:Config {}
 public function testConnectionError() returns Error? {
-   Error|Client wsClient = new ("ws://lmnop.ls", config = config);
+   Error|Client wsClient = new ("ws://lmnop.ls", options = config);
    if (wsClient is Error) {
        test:assertEquals(wsClient.message(), "ConnectionError: IO Error");
    } else {
@@ -129,7 +129,7 @@ public function testConnectionClosedError() returns Error? {
 // Handshake failing because of missing subprotocol
 @test:Config {}
 public function testHandshakeError() returns Error? {
-   Error|Client wsClientEp = new ("ws://localhost:21030/websocket", config = config);
+   Error|Client wsClientEp = new ("ws://localhost:21030/websocket", options = config);
    if (wsClientEp is Error) {
       errMessage = wsClientEp.message();
    }

--- a/websocket-ballerina/tests/websocket_ssl_proxy.bal
+++ b/websocket-ballerina/tests/websocket_ssl_proxy.bal
@@ -36,7 +36,7 @@ service /sslEcho on l24 {
 service class SslProxy {
    *Service;
    remote function onOpen(Caller wsEp) returns Error? {
-       Client wsClientEp = check new ("wss://localhost:21028/websocket", config = {
+       Client wsClientEp = check new ("wss://localhost:21028/websocket", options = {
                secureSocket: {
                    cert: {
                        path: TRUSTSTORE_PATH,
@@ -102,7 +102,7 @@ service class SslProxyServer {
 // Tests sending and receiving of text frames in WebSockets over SSL.
 @test:Config {}
 public function testSslProxySendText() returns Error? {
-   Client wsClient = check new ("wss://localhost:21027/sslEcho", config = {
+   Client wsClient = check new ("wss://localhost:21027/sslEcho", options = {
            secureSocket: {
                cert: {
                    path: TRUSTSTORE_PATH,
@@ -120,7 +120,7 @@ public function testSslProxySendText() returns Error? {
 // Tests sending and receiving of binary frames in WebSocket over SSL.
 @test:Config {}
 public function testSslProxySendBinary() returns Error? {
-   Client wsClient = check new ("wss://localhost:21027/sslEcho", config = {
+   Client wsClient = check new ("wss://localhost:21027/sslEcho", options = {
            secureSocket: {
                cert: {
                    path: TRUSTSTORE_PATH,

--- a/websocket-ballerina/websocket_async_client.bal
+++ b/websocket-ballerina/websocket_async_client.bal
@@ -207,7 +207,7 @@ import ballerina/mime;
 # | handShakeTimeout - Copied from CommonClientConfiguration   |
 # | cookies - Copied from CommonClientConfiguration                     |
 //# + retryConfig - Retry related configurations
-public type ClientConfiguration record {|
+public type ClientOptions record {|
     *CommonClientConfiguration;
     //WebSocketRetryConfig retryConfig?;
 |};
@@ -249,7 +249,7 @@ public type ClientSecureSocket record {|
 # Adds cookies to the custom header.
 #
 # + config - Represents the cookies to be added
-public isolated function addCookies(ClientConfiguration config) {
+public isolated function addCookies(ClientOptions config) {
    string cookieHeader = "";
    var cookiesToAdd = config["cookies"];
    if (cookiesToAdd is http:Cookie[]) {

--- a/websocket-ballerina/websocket_sync_client.bal
+++ b/websocket-ballerina/websocket_sync_client.bal
@@ -29,19 +29,19 @@ public client class Client {
 
     private WebSocketConnector conn = new;
     private string url = "";
-    private ClientConfiguration config = {};
+    private ClientOptions config = {};
     private PingPongService? pingPongService = ();
 
     # Initializes the synchronous client when called.
     #
     # + url - URL of the target service
     # + config - The configurations to be used when initializing the client
-    public isolated function init(string url, *ClientConfiguration config) returns Error? {
+    public isolated function init(string url, *ClientOptions options) returns Error? {
         self.url = url;
-        addCookies(config);
-        check initClientAuth(config);
-        self.config = config;
-        var pingPongHandler = config["pingPongHandler"];
+        addCookies(options);
+        check initClientAuth(options);
+        self.config = options;
+        var pingPongHandler = options["pingPongHandler"];
         if (pingPongHandler is PingPongService) {
             self.pingPongService = pingPongHandler;
         }


### PR DESCRIPTION
## Purpose
Renamed ListerConfiguration to ListenerOptions and ClientConfiguration to ClientOptions.

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1090