### PR TITLE
Add validations to invalidate provided configurations if the http listener is given as the websocket listener

### DIFF
--- a/websocket-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websocket/compiler/WebSocketServiceValidationTest.java
+++ b/websocket-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websocket/compiler/WebSocketServiceValidationTest.java
@@ -422,6 +422,17 @@ public class WebSocketServiceValidationTest {
 
     }
 
+    @Test
+    public void testHttpListenerAsWsListenerWithConfigs() {
+        Package currentPackage = loadPackage("sample_package_34");
+        PackageCompilation compilation = currentPackage.getCompilation();
+
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_LISTENER_INIT_PARAMS);
+    }
+
     private void assertDiagnostic(Diagnostic diagnostic, PluginConstants.CompilationErrors error) {
         Assert.assertEquals(diagnostic.diagnosticInfo().code(), error.getErrorCode());
         Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),

--- a/websocket-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websocket/compiler/WebSocketServiceValidationTest.java
+++ b/websocket-compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websocket/compiler/WebSocketServiceValidationTest.java
@@ -119,9 +119,11 @@ public class WebSocketServiceValidationTest {
         PackageCompilation compilation = currentPackage.getCompilation();
 
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.diagnostics().size(), 1);
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 2);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.diagnostics().toArray()[0];
-        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE);
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_LISTENER_INIT_PARAMS);
+        Diagnostic diagnostic2 = (Diagnostic) diagnosticResult.diagnostics().toArray()[1];
+        assertDiagnostic(diagnostic2, PluginConstants.CompilationErrors.FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE);
     }
 
     @Test

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
@@ -2,11 +2,20 @@ import ballerina/websocket;
 import ballerina/http;
 import ballerina/io;
 
+websocket:ListenerConfiguration conf = {
+               secureSocket: {
+                        key: {
+                            path: "tests/certsAndKeys/ballerinaKeystore.p12",
+                            password: "ballerina"
+                        }
+                    }
+               };
+
 @websocket:ServiceConfig {
     subProtocols: ["xml", "json"],
     idleTimeout: 120
 }
-service /basic/ws on new websocket:Listener(9090) {
+service /basic/ws on new websocket:Listener(9090, conf) {
    resource isolated function get .(http:Request req) returns websocket:Service|websocket:UpgradeError {
        lock {
            self.testFunc();

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
@@ -10,6 +10,7 @@ service /basic/ws on new websocket:Listener(9090, {
                       }
                  }) {
    resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
+       io:println("Invoked the function");
        return new WsService();
    }
 }

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
@@ -1,7 +1,14 @@
 import ballerina/websocket;
 import ballerina/io;
 
-service /basic/ws on new websocket:Listener(9090) {
+service /basic/ws on new websocket:Listener(9090, {
+                 secureSocket: {
+                          key: {
+                              path: "tests/certsAndKeys/ballerinaKeystore.p12",
+                              password: "ballerina"
+                          }
+                      }
+                 }) {
    resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
        return new WsService();
    }

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/Ballerina.toml
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "websocket_test"
+name = "sample_34"
+version = "0.1.0"

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
@@ -1,0 +1,34 @@
+import ballerina/websocket;
+import ballerina/http;
+
+listener http:Listener hl = check new(21001);
+websocket:ListenerConfiguration conf = {
+               secureSocket: {
+                        key: {
+                            path: "tests/certsAndKeys/ballerinaKeystore.p12",
+                            password: "ballerina"
+                        }
+                    }
+               };
+listener websocket:Listener socketListener = new(hl, conf);
+
+service /basic/ws on socketListener {
+   resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
+       return new WsService();
+   }
+}
+
+service class WsService {
+    *websocket:Service;
+    remote function onOpen(websocket:Caller caller) {
+    }
+
+    remote function onTextMessage(websocket:Caller caller, string text) returns error? {
+    }
+}
+
+service /helloWorld on hl {
+    resource function get hello(http:Caller caller, http:Request req) returns error? {
+        check caller->respond("Hello World!");
+    }
+}

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
@@ -1,5 +1,6 @@
 import ballerina/websocket;
 import ballerina/http;
+import ballerina/io;
 
 listener http:Listener hl = check new(21001);
 websocket:ListenerConfiguration conf = {
@@ -14,6 +15,7 @@ listener websocket:Listener socketListener = new(hl, conf);
 
 service /basic/ws on socketListener {
    resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
+       io:println("hello");
        return new WsService();
    }
 }

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_34/service.bal
@@ -2,7 +2,17 @@ import ballerina/websocket;
 import ballerina/http;
 import ballerina/io;
 
-listener http:Listener hl = check new(21001);
+http:ListenerConfiguration httpConf = {
+               secureSocket: {
+                        key: {
+                            path: "tests/certsAndKeys/ballerinaKeystore.p12",
+                            password: "ballerina"
+                        }
+                    }
+               };
+
+listener http:Listener hl = new(21001, httpConf);
+
 websocket:ListenerConfiguration conf = {
                secureSocket: {
                         key: {

--- a/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/websocket-compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -2,7 +2,14 @@ import ballerina/websocket;
 import ballerina/http;
 
 listener http:Listener hl = check new(21001);
-listener websocket:Listener socketListener = new(<@untainted> hl);
+listener websocket:Listener socketListener = new(<@untainted> hl, {
+                             secureSocket: {
+                                      key: {
+                                          path: "tests/certsAndKeys/ballerinaKeystore.p12",
+                                          password: "ballerina"
+                                      }
+                                  }
+                             });
 
 service /basic/ws on socketListener {
    remote isolated function get() returns websocket:Service|websocket:UpgradeError {

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/ListenerInitExpressionNodeVisitor.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/ListenerInitExpressionNodeVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.websocket.plugin;
+
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@code ListenerDeclarationVisitor} find the available listener declarations.
+ */
+public class ListenerInitExpressionNodeVisitor extends NodeVisitor {
+
+    private final List<ImplicitNewExpressionNode> implicitNewExpressionNodes = new ArrayList<>();
+    private final List<ExplicitNewExpressionNode> explicitNewExpressionNodes = new ArrayList<>();
+
+    @Override
+    public void visit(ImplicitNewExpressionNode node) {
+        if (node.parent() instanceof ListenerDeclarationNode) {
+            implicitNewExpressionNodes.add(node);
+        }
+    }
+
+    @Override
+    public void visit(ExplicitNewExpressionNode node) {
+        if (node.typeDescriptor() instanceof QualifiedNameReferenceNode) {
+            explicitNewExpressionNodes.add(node);
+        }
+    }
+
+    List<ImplicitNewExpressionNode> getImplicitNewExpressionNodes() {
+        return implicitNewExpressionNodes;
+    }
+
+    List<ExplicitNewExpressionNode> getExplicitNewExpressionNodes() {
+        return explicitNewExpressionNodes;
+    }
+}

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/ListenerInitExpressionNodeVisitor.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/ListenerInitExpressionNodeVisitor.java
@@ -18,14 +18,26 @@
 
 package io.ballerina.stdlib.websocket.plugin;
 
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import org.ballerinalang.net.websocket.WebSocketConstants;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * {@code ListenerDeclarationVisitor} find the available listener declarations.
@@ -34,19 +46,63 @@ public class ListenerInitExpressionNodeVisitor extends NodeVisitor {
 
     private final List<ImplicitNewExpressionNode> implicitNewExpressionNodes = new ArrayList<>();
     private final List<ExplicitNewExpressionNode> explicitNewExpressionNodes = new ArrayList<>();
+    private SyntaxNodeAnalysisContext ctx;
 
+    public ListenerInitExpressionNodeVisitor(SyntaxNodeAnalysisContext ctx) {
+        this.ctx = ctx;
+    }
     @Override
     public void visit(ImplicitNewExpressionNode node) {
         if (node.parent() instanceof ListenerDeclarationNode) {
-            implicitNewExpressionNodes.add(node);
+            ListenerDeclarationNode parentNode = (ListenerDeclarationNode) node.parent();
+            Optional<TypeDescriptorNode> parentTypeOpt = parentNode.typeDescriptor();
+            if (parentTypeOpt.isPresent()) {
+                QualifiedNameReferenceNode parentType = (QualifiedNameReferenceNode) parentTypeOpt.get();
+                Optional<Symbol> parentSymbolOpt = ctx.semanticModel().symbol(parentType);
+                if (parentSymbolOpt.isPresent() && parentSymbolOpt.get() instanceof TypeReferenceTypeSymbol) {
+                    TypeSymbol typeSymbol = ((TypeReferenceTypeSymbol) parentSymbolOpt.get()).typeDescriptor();
+                    if (typeSymbol.typeKind() == TypeDescKind.OBJECT) {
+                        ObjectTypeSymbol objectSymbol = (ObjectTypeSymbol) typeSymbol;
+                        Optional<ModuleID> moduleId = objectSymbol.getModule().map(ModuleSymbol::id);
+                        String identifier = objectSymbol.getName().orElse("");
+                        if (moduleId.isPresent() && isWebSocketListener(moduleId.get(), identifier)) {
+                            implicitNewExpressionNodes.add(node);
+                        }
+                    }
+                }
+            }
         }
     }
 
     @Override
     public void visit(ExplicitNewExpressionNode node) {
         if (node.typeDescriptor() instanceof QualifiedNameReferenceNode) {
-            explicitNewExpressionNodes.add(node);
+            QualifiedNameReferenceNode nameRef = (QualifiedNameReferenceNode) node.typeDescriptor();
+            Optional<Symbol> symbolOpt = ctx.semanticModel().symbol(nameRef);
+            if (symbolOpt.isPresent() && symbolOpt.get() instanceof TypeReferenceTypeSymbol) {
+                TypeSymbol typeSymbol = ((TypeReferenceTypeSymbol) symbolOpt.get()).typeDescriptor();
+                if (typeSymbol.typeKind() == TypeDescKind.UNION) {
+                    Optional<TypeSymbol> refSymbolOpt = ((UnionTypeSymbol) typeSymbol).memberTypeDescriptors()
+                            .stream().filter(e -> e.typeKind() == TypeDescKind.TYPE_REFERENCE).findFirst();
+                    if (refSymbolOpt.isPresent()) {
+                        TypeReferenceTypeSymbol refSymbol = (TypeReferenceTypeSymbol) refSymbolOpt.get();
+                        TypeSymbol typeDescriptor = refSymbol.typeDescriptor();
+                        Optional<ModuleID> moduleId = typeDescriptor.getModule().map(ModuleSymbol::id);
+                        String identifier = typeDescriptor.getName().orElse("");
+                        if (moduleId.isPresent() && isWebSocketListener(moduleId.get(), identifier)) {
+                            explicitNewExpressionNodes.add(node);
+                        }
+                    }
+                }
+            }
         }
+    }
+
+    private boolean isWebSocketListener(ModuleID moduleID, String identifier) {
+        String orgName = moduleID.orgName();
+        String packagePrefix = moduleID.modulePrefix();
+        return WebSocketConstants.PACKAGE_WEBSOCKET.equals(packagePrefix) && PluginConstants.ORG_NAME.equals(orgName)
+                && PluginConstants.LISTENER_IDENTIFIER.equals(identifier);
     }
 
     List<ImplicitNewExpressionNode> getImplicitNewExpressionNodes() {

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/PluginConstants.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/PluginConstants.java
@@ -27,6 +27,7 @@ public class PluginConstants {
     public static final String SERVICE = "Service";
     public static final String PIPE = "|";
     public static final String UPGRADE_ERROR = "UpgradeError";
+    public static final String ORG_NAME = "ballerina";
     static final String ON_ERROR = "onError";
     static final String ON_OPEN = "onOpen";
     static final String ON_CLOSE = "onClose";
@@ -36,6 +37,7 @@ public class PluginConstants {
     static final String REMOTE_KEY_WORD = "remote";
     static final String RESOURCE_KEY_WORD = "resource";
     static final String HTTP_REQUEST = "http:Request";
+    static final String LISTENER_IDENTIFIER = "Listener";
 
     /**
      * Compilation Errors of WebSocket module.

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/PluginConstants.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/PluginConstants.java
@@ -77,7 +77,9 @@ public class PluginConstants {
         INVALID_RETURN_TYPES_IN_RESOURCE("Invalid return type `{0}` provided for function `{1}`, return type "
                 + "should be a subtype of `{2}`", "WEBSOCKET_104"),
         FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE("Function `{0}` not accepted by the service",
-                "WEBSOCKET_105");
+                "WEBSOCKET_105"),
+        INVALID_LISTENER_INIT_PARAMS("`websocket:ListenerConfiguration` not allowed with `http:Listener` "
+                + "as the `websocket:Listener` ", "WEBSOCKET_106");
 
         private final String error;
         private final String errorCode;

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketServiceValidator.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketServiceValidator.java
@@ -23,8 +23,6 @@ import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
-import io.ballerina.tools.diagnostics.DiagnosticFactory;
-import io.ballerina.tools.diagnostics.DiagnosticInfo;
 
 /**
  * A class for validating websocket service.
@@ -77,9 +75,7 @@ public class WebSocketServiceValidator {
     }
 
     private void reportInvalidFunction(FunctionDefinitionNode functionDefinitionNode) {
-        DiagnosticInfo diagnosticInfo = Utils
-                .getDiagnosticInfo(PluginConstants.CompilationErrors.FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE);
-        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo,
-                functionDefinitionNode.location(), functionDefinitionNode.functionName().toString()));
+        Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE,
+                functionDefinitionNode.location(), functionDefinitionNode.functionName().toString());
     }
 }

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
@@ -62,10 +62,6 @@ public class WebSocketUpgradeServiceValidator {
             int numResources = (int) serviceDeclarationNode.members().stream()
                     .filter(child -> child.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION).count();
             if (numResources > 1) {
-//                DiagnosticInfo diagnosticInfo = Utils
-//                        .getDiagnosticInfo(PluginConstants.CompilationErrors.INVALID_RESOURCE_ERROR);
-//                ctx.reportDiagnostic(
-//                        DiagnosticFactory.createDiagnostic(diagnosticInfo, serviceDeclarationNode.location()));
                 Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RESOURCE_ERROR,
                         serviceDeclarationNode.location());
             }

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
@@ -35,8 +35,6 @@ import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
-import io.ballerina.tools.diagnostics.DiagnosticFactory;
-import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import org.ballerinalang.net.websocket.WebSocketConstants;
 
 import java.util.List;
@@ -64,10 +62,12 @@ public class WebSocketUpgradeServiceValidator {
             int numResources = (int) serviceDeclarationNode.members().stream()
                     .filter(child -> child.kind() == SyntaxKind.RESOURCE_ACCESSOR_DEFINITION).count();
             if (numResources > 1) {
-                DiagnosticInfo diagnosticInfo = Utils
-                        .getDiagnosticInfo(PluginConstants.CompilationErrors.INVALID_RESOURCE_ERROR);
-                ctx.reportDiagnostic(
-                        DiagnosticFactory.createDiagnostic(diagnosticInfo, serviceDeclarationNode.location()));
+//                DiagnosticInfo diagnosticInfo = Utils
+//                        .getDiagnosticInfo(PluginConstants.CompilationErrors.INVALID_RESOURCE_ERROR);
+//                ctx.reportDiagnostic(
+//                        DiagnosticFactory.createDiagnostic(diagnosticInfo, serviceDeclarationNode.location()));
+                Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RESOURCE_ERROR,
+                        serviceDeclarationNode.location());
             }
         }
         serviceDeclarationNode.members().stream().filter(child -> child.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION
@@ -133,19 +133,14 @@ public class WebSocketUpgradeServiceValidator {
         if (resourceNode != null) {
             SeparatedNodeList<ParameterNode> parameterNodes = resourceNode.functionSignature().parameters();
             if (parameterNodes.size() > 1) {
-                DiagnosticInfo diagnosticInfo = Utils
-                        .getDiagnosticInfo(PluginConstants.CompilationErrors.MORE_THAN_ONE_RESOURCE_PARAM_ERROR);
-                ctx.reportDiagnostic(DiagnosticFactory
-                        .createDiagnostic(diagnosticInfo, resourceNode.location()));
+                Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.MORE_THAN_ONE_RESOURCE_PARAM_ERROR,
+                        resourceNode.location());
             } else if (!parameterNodes.isEmpty()) {
                 RequiredParameterNode requiredParameterNode = (RequiredParameterNode) parameterNodes.get(0);
                 Node parameterTypeName = requiredParameterNode.typeName();
                 if (!parameterTypeName.toString().contains(PluginConstants.HTTP_REQUEST)) {
-                    DiagnosticInfo diagnosticInfo = Utils
-                            .getDiagnosticInfo(PluginConstants.CompilationErrors.INVALID_RESOURCE_PARAMETER_ERROR);
-                    ctx.reportDiagnostic(DiagnosticFactory
-                            .createDiagnostic(diagnosticInfo, resourceNode.location(), parameterTypeName.toString(),
-                                    PluginConstants.HTTP_REQUEST));
+                    Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RESOURCE_PARAMETER_ERROR,
+                            resourceNode.location(), PluginConstants.HTTP_REQUEST);
                 }
             }
         }
@@ -156,9 +151,8 @@ public class WebSocketUpgradeServiceValidator {
             Optional<ReturnTypeDescriptorNode> returnTypesNode = resourceNode
                     .functionSignature().returnTypeDesc();
             if (resourceNode.functionSignature().returnTypeDesc().isEmpty()) {
-                DiagnosticInfo diagnosticInfo = Utils
-                        .getDiagnosticInfo(PluginConstants.CompilationErrors.INVALID_RETURN_TYPES_IN_RESOURCE);
-                ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, resourceNode.location()));
+                Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RETURN_TYPES_IN_RESOURCE,
+                        resourceNode.location());
             }
             Node returnTypeDescriptor = returnTypesNode.get().type();
             String returnTypeDescWithoutTrailingSpace = returnTypeDescriptor.toString().split(" ")[0];
@@ -166,21 +160,17 @@ public class WebSocketUpgradeServiceValidator {
                     modulePrefix + PluginConstants.SERVICE + PIPE + modulePrefix + PluginConstants.UPGRADE_ERROR))
                     && !(returnTypeDescWithoutTrailingSpace.equals(
                     modulePrefix + PluginConstants.UPGRADE_ERROR + PIPE + modulePrefix + PluginConstants.SERVICE))) {
-                DiagnosticInfo diagnosticInfo = Utils
-                        .getDiagnosticInfo(PluginConstants.CompilationErrors.INVALID_RETURN_TYPES_IN_RESOURCE);
-                ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, returnTypeDescriptor.location(),
-                        returnTypeDescriptor.toString(), resourceNode.functionName(),
+                Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RETURN_TYPES_IN_RESOURCE,
+                        resourceNode.location(), returnTypeDescriptor.toString(), resourceNode.functionName(),
                         modulePrefix + PluginConstants.SERVICE + PluginConstants.PIPE + modulePrefix
-                                + PluginConstants.UPGRADE_ERROR));
+                                + PluginConstants.UPGRADE_ERROR);
             }
 
         }
     }
 
-    void reportInvalidFunction(FunctionDefinitionNode functionDefinitionNode) {
-        DiagnosticInfo diagnosticInfo = Utils
-                .getDiagnosticInfo(PluginConstants.CompilationErrors.FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE);
-        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, functionDefinitionNode.location(),
-                functionDefinitionNode.functionName().toString()));
+    private void reportInvalidFunction(FunctionDefinitionNode functionDefinitionNode) {
+        Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.FUNCTION_NOT_ACCEPTED_BY_THE_SERVICE,
+                functionDefinitionNode.location(), functionDefinitionNode.functionName().toString());
     }
 }

--- a/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
+++ b/websocket-compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
@@ -34,19 +34,17 @@ import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
-import io.ballerina.tools.diagnostics.DiagnosticFactory;
-import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import org.ballerinalang.net.websocket.WebSocketConstants;
 
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.websocket.plugin.PluginConstants.ORG_NAME;
+
 /**
  * Validates a Ballerina WebSocket Upgrade Service.
  */
 public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
-
-    private static final String ORG_NAME = "ballerina";
 
     @Override
     public void perform(SyntaxNodeAnalysisContext ctx) {
@@ -59,7 +57,7 @@ public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<Syntax
                     .listenerTypes();
             for (TypeSymbol listenerType : listenerTypes) {
                 if (isListenerBelongsToWebSocketModule(listenerType)) {
-                    ListenerInitExpressionNodeVisitor visitor = new ListenerInitExpressionNodeVisitor();
+                    ListenerInitExpressionNodeVisitor visitor = new ListenerInitExpressionNodeVisitor(ctx);
                     serviceDeclarationNode.syntaxTree().rootNode().accept(visitor);
                     validateListenerArguments(ctx, visitor);
                     validateService(ctx, modulePrefix);
@@ -113,10 +111,8 @@ public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<Syntax
             if (!(firstArgSyntaxKind == SyntaxKind.NUMERIC_LITERAL && (
                     secondArgSyntaxKind == SyntaxKind.SIMPLE_NAME_REFERENCE
                             || secondArgSyntaxKind == SyntaxKind.MAPPING_CONSTRUCTOR))) {
-                DiagnosticInfo diagnosticInfo = Utils.getDiagnosticInfo(
-                        PluginConstants.CompilationErrors.INVALID_LISTENER_INIT_PARAMS);
-                context.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticInfo, location,
-                        WebSocketConstants.PACKAGE_WEBSOCKET));
+                Utils.reportDiagnostics(context, PluginConstants.CompilationErrors.INVALID_LISTENER_INIT_PARAMS,
+                        location, WebSocketConstants.PACKAGE_WEBSOCKET);
             }
         }
     }


### PR DESCRIPTION
## Purpose
Add validations to invalidate provided configurations if the http listener is given as the websocket listener
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1275

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog(N/A)
- [x] Added tests