### PR TITLE
Cancel the websocket handshake when panicked from the initial get resource

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Fixed
+### Added
 - [Implement declarative auth design for upgrade service](https://github.com/ballerina-platform/ballerina-standard-library/issues/1405)
+
+### Fixed
 - [Remove the countdown latches in the implementation](https://github.com/ballerina-platform/ballerina-standard-library/issues/1385)
+- [Fix the issue of not sending the handshake cancel response when panicked from the upgrade service](https://github.com/ballerina-platform/ballerina-standard-library/issues/1439)
 
 ## [1.2.0-beta.1] - 2021-05-06
 

--- a/websocket-ballerina/tests/test_upgrade_service_panic.bal
+++ b/websocket-ballerina/tests/test_upgrade_service_panic.bal
@@ -42,7 +42,7 @@ public function testPanicErrorFromUpgradeService() returns Error? {
         test:assertEquals(wsClient.message(), "InvalidHandshakeError: Invalid handshake response getStatus: "
                                + "500 Internal Server Error");
     } else {
-        test:assertFail("Should return a InvalidHandshakeError");
+        test:assertFail("Should return an InvalidHandshakeError");
         error? result = wsClient->close(1001, "Close the connection", timeout = 0);
     }
 }

--- a/websocket-ballerina/tests/test_upgrade_service_panic.bal
+++ b/websocket-ballerina/tests/test_upgrade_service_panic.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+listener Listener l75 = new(21075);
+
+service /onPanic on l75 {
+    resource function get .() returns Service|UpgradeError {
+        if (true) {
+           panic error("panic from the service");
+        }
+        return new WsService75();
+    }
+}
+
+service class WsService75 {
+    *Service;
+    remote function onTextMessage(Caller caller, string data) returns error? {
+        return error("error returned");
+    }
+}
+
+// Tests error panicked from get resource.
+@test:Config {}
+public function testPanicErrorFromUpgradeService() returns Error? {
+    Client|Error wsClient = new ("ws://localhost:21075/onPanic/");
+    if (wsClient is Error) {
+        test:assertEquals(wsClient.message(), "InvalidHandshakeError: Invalid handshake response getStatus: "
+                               + "500 Internal Server Error");
+    } else {
+        test:assertFail("Should return a InvalidHandshakeError");
+        error? result = wsClient->close(1001, "Close the connection", timeout = 0);
+    }
+}

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/server/OnUpgradeResourceCallback.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/server/OnUpgradeResourceCallback.java
@@ -73,7 +73,8 @@ public class OnUpgradeResourceCallback implements Callback {
         }
     }
 
-    @Override public void notifyFailure(BError error) {
+    @Override
+    public void notifyFailure(BError error) {
         // These checks are added to release the failure path since there is an authn/authz failure and responded
         // with 401/403 internally.
         if (error.getMessage().equals("401 received by auth desugar.")) {

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/server/OnUpgradeResourceCallback.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/server/OnUpgradeResourceCallback.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpHeaders;
 import org.ballerinalang.net.transport.contract.websocket.ServerHandshakeFuture;
 import org.ballerinalang.net.transport.contract.websocket.WebSocketHandshaker;
 import org.ballerinalang.net.websocket.WebSocketConstants;
-import org.ballerinalang.net.websocket.WebSocketUtil;
 
 import static org.ballerinalang.net.websocket.WebSocketConstants.CUSTOM_HEADERS;
 
@@ -74,8 +73,7 @@ public class OnUpgradeResourceCallback implements Callback {
         }
     }
 
-    @Override
-    public void notifyFailure(BError error) {
+    @Override public void notifyFailure(BError error) {
         // These checks are added to release the failure path since there is an authn/authz failure and responded
         // with 401/403 internally.
         if (error.getMessage().equals("401 received by auth desugar.")) {
@@ -86,16 +84,9 @@ public class OnUpgradeResourceCallback implements Callback {
             webSocketHandshaker.cancelHandshake(403, error.getMessage());
             return;
         }
+        // When panicked from the upgrade service.
         error.printStackTrace();
-        WebSocketConnectionInfo connectionInfo =
-                connectionManager.getConnectionInfo(webSocketHandshaker.getChannelId());
-        if (connectionInfo != null) {
-            try {
-                WebSocketUtil.closeDuringUnexpectedCondition(connectionInfo.getWebSocketConnection());
-            } catch (IllegalAccessException e) {
-                // Ignore as it is not possible have an Illegal access
-            }
-        }
+        webSocketHandshaker.cancelHandshake(500, error.getMessage());
     }
 
     private static DefaultHttpHeaders populateAndGetHttpHeaders(BMap<BString, BString> headers) {


### PR DESCRIPTION
## Purpose
Fix the issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/1439
If the initial get resource to which upgrade request gets dispatched panics, a 500 Internal server error will be sent as the response to the initial WebSocket upgrade request. 

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests