### PR TITLE
Implement Client handshake timeout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - [Remove the countdown latches in the implementation](https://github.com/ballerina-platform/ballerina-standard-library/issues/1385)
 - [Fix the issue of not sending the handshake cancel response when panicked from the upgrade service](https://github.com/ballerina-platform/ballerina-standard-library/issues/1439)
+- [Fix the client handshake timeout not working](https://github.com/ballerina-platform/ballerina-standard-library/issues/1478)
 
 ## [1.2.0-beta.1] - 2021-05-06
 

--- a/websocket-ballerina/tests/client_handshake_timeout_test.bal
+++ b/websocket-ballerina/tests/client_handshake_timeout_test.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/websocket-ballerina/tests/client_handshake_timeout_test.bal
+++ b/websocket-ballerina/tests/client_handshake_timeout_test.bal
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 WSO2 Inc. (//www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.runtime as runtime;
+import ballerina/test;
+import ballerina/io;
+
+listener Listener l71 = new(21076);
+
+service /onTextString on l71 {
+   resource function get .() returns Service|UpgradeError {
+       runtime:sleep(2);
+       return new WsService71();
+   }
+}
+
+service class WsService71 {
+  *Service;
+  remote isolated function onTextMessage(Caller caller, string data) returns string? {
+      runtime:sleep(5);
+      io:println("server on text message");
+      return data;
+  }
+
+  remote isolated function onError(error err) returns Error? {
+      io:println("server on error message");
+  }
+}
+
+// Tests client handshake timeout
+@test:Config {}
+public function testHandshakeTimeoutError() returns Error? {
+   Client|Error wsClient = new("ws://localhost:21076/onTextString", { handShakeTimeout: 1 });
+   if (wsClient is Client) {
+      test:assertFail("Expected a handshake timeout error");
+   } else {
+      io:println(wsClient.message());
+      test:assertEquals("Error: Handshake timed out", wsClient.message());
+   }
+}
+
+// Tests reset timeout after a successful handshake
+@test:Config {}
+public function testResetTimeoutAfterHandshake() returns Error? {
+   Client|Error wsClient = new("ws://localhost:21076/onTextString", { handShakeTimeout: 4 });
+   if (wsClient is Client) {
+       check wsClient->writeTextMessage("Hello Ballerina");
+       Error|string data = wsClient->readTextMessage();
+       if (data is string) {
+          test:assertEquals("Hello Ballerina", data);
+       } else {
+          test:assertFail("Should read the content without any error");
+       }
+   } else {
+      test:assertFail("Should connect without any error");
+   }
+}

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -43,6 +43,7 @@ public class WebSocketConstants {
     public static final BString ANNOTATION_ATTR_IDLE_TIMEOUT = StringUtils.fromString("idleTimeout");
     public static final BString ANNOTATION_ATTR_READ_IDLE_TIMEOUT = StringUtils.fromString("readTimeout");
     public static final BString ANNOTATION_ATTR_TIMEOUT = StringUtils.fromString("timeout");
+    public static final BString ANNOTATION_ATTR_CLIENT_HANDSHAKE_TIMEOUT = StringUtils.fromString("handShakeTimeout");
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");
 
     public static final String RESOURCE_NAME_ON_OPEN = "onOpen";

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/WebSocketConstants.java
@@ -43,7 +43,6 @@ public class WebSocketConstants {
     public static final BString ANNOTATION_ATTR_IDLE_TIMEOUT = StringUtils.fromString("idleTimeout");
     public static final BString ANNOTATION_ATTR_READ_IDLE_TIMEOUT = StringUtils.fromString("readTimeout");
     public static final BString ANNOTATION_ATTR_TIMEOUT = StringUtils.fromString("timeout");
-    public static final BString ANNOTATION_ATTR_CLIENT_HANDSHAKE_TIMEOUT = StringUtils.fromString("handShakeTimeout");
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");
 
     public static final String RESOURCE_NAME_ON_OPEN = "onOpen";
@@ -81,6 +80,7 @@ public class WebSocketConstants {
     public static final String CONNECTOR_FACTORY = "connectorFactory";
     public static final String FAILOVER_WEBSOCKET_CLIENT = "WebSocketFailoverClient";
     public static final BString ENDPOINT_CONFIG_SECURE_SOCKET = StringUtils.fromString("secureSocket");
+    public static final BString CLIENT_HANDSHAKE_TIMEOUT = StringUtils.fromString("handShakeTimeout");
 
     public static final String PACKAGE = "ballerina";
     public static final String PROTOCOL_WEBSOCKET = "websocket";

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/SyncInitEndpoint.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/SyncInitEndpoint.java
@@ -40,6 +40,7 @@ import java.net.URI;
 
 import static org.ballerinalang.net.websocket.WebSocketConstants.SYNC_CLIENT_SERVICE_CONFIG;
 import static org.ballerinalang.net.websocket.WebSocketUtil.findMaxFrameSize;
+import static org.ballerinalang.net.websocket.WebSocketUtil.findTimeoutInSeconds;
 
 /**
  * Initialize the WebSocket Synchronous Client.
@@ -92,6 +93,9 @@ public class SyncInitEndpoint {
         clientConnectorConfig.setAutoRead(false); // Frames should be read only when client starts reading
         clientConnectorConfig.setSubProtocols(WebSocketUtil.findNegotiableSubProtocols(clientEndpointConfig));
         @SuppressWarnings(WebSocketConstants.UNCHECKED)
+        long handshakeTimeoutInSeconds = findTimeoutInSeconds(clientEndpointConfig,
+                WebSocketConstants.ANNOTATION_ATTR_CLIENT_HANDSHAKE_TIMEOUT, 300);
+        clientConnectorConfig.setIdleTimeoutInMillis(Math.toIntExact(handshakeTimeoutInSeconds) * 1000);
         BMap<BString, Object> headerValues = (BMap<BString, Object>) clientEndpointConfig
                 .getMapValue(WebSocketConstants.CUSTOM_HEADERS);
         if (headerValues != null) {

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/SyncInitEndpoint.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/SyncInitEndpoint.java
@@ -94,7 +94,7 @@ public class SyncInitEndpoint {
         clientConnectorConfig.setSubProtocols(WebSocketUtil.findNegotiableSubProtocols(clientEndpointConfig));
         @SuppressWarnings(WebSocketConstants.UNCHECKED)
         long handshakeTimeoutInSeconds = findTimeoutInSeconds(clientEndpointConfig,
-                WebSocketConstants.ANNOTATION_ATTR_CLIENT_HANDSHAKE_TIMEOUT, 300);
+                WebSocketConstants.CLIENT_HANDSHAKE_TIMEOUT, 300);
         clientConnectorConfig.setIdleTimeoutInMillis(Math.toIntExact(handshakeTimeoutInSeconds) * 1000);
         BMap<BString, Object> headerValues = (BMap<BString, Object>) clientEndpointConfig
                 .getMapValue(WebSocketConstants.CUSTOM_HEADERS);

--- a/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/listener/WebSocketHandshakeListener.java
+++ b/websocket-native/src/main/java/org/ballerinalang/net/websocket/client/listener/WebSocketHandshakeListener.java
@@ -57,6 +57,7 @@ public class WebSocketHandshakeListener implements ClientHandshakeListener {
         WebSocketUtil.populateClientWebSocketEndpoint(webSocketConnection, webSocketClient);
         setWebSocketOpenConnectionInfo(webSocketConnection, webSocketClient, wsService);
         connectorListener.setConnectionInfo(connectionInfo);
+        webSocketConnection.removeReadIdleStateHandler();
         balFuture.complete(null);
         WebSocketObservabilityUtil.observeConnection(connectionInfo);
     }


### PR DESCRIPTION
## Purpose
This is to implement the handshake timeout for the client. Client can set the handshake timeout as a client configuration.
Once the waiting time exceeds, an error `Error: Handshake timed out` is returned.
After successfully completing the handshake, timeout handler will be removed to reset the timeout as this is only applicable for the initial WebSocket upgrade handshake.

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1478

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests