### PR TITLE
Re-enable compiler plugin tests and fix error type validation

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,12 +19,6 @@ jobs:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew build
-      - name: Archive Code Coverage JSON
-        uses: actions/upload-artifact@v2
-        with:
-          name: Code Coverage JSON
-          path: websocket-ballerina/target/report/test_results.json
-          if-no-files-found: ignore
       - name: Generate Codecov Report
         if:  github.event_name == 'pull_request'
         uses: codecov/codecov-action@v1

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -24,12 +24,12 @@ plugins {
 
 description = 'Ballerina - WebSocket Compiler Plugin Tests'
 
-def ballerinaModulePath = "${project.rootDir}/websocket-ballerina/"
+def ballerinaModulePath = "${project.rootDir}/ballerina/"
 def ballerinaDistPath = "${ballerinaModulePath}/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
 def ballerinaDist = "${buildDir}/target/ballerina-distribution"
 
 dependencies {
-    checkstyle project(':build-config:checkstyle')
+    checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
 
     testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
@@ -49,7 +49,7 @@ checkstyle {
     configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
 }
 
-checkstyleTest.dependsOn(":build-config:checkstyle:downloadCheckstyleRuleFiles")
+checkstyleTest.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
 
 spotbugsTest {
     effort "max"

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
@@ -19,7 +19,6 @@
 package io.ballerina.stdlib.websocket.plugin;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
-import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -156,7 +155,8 @@ public class WebSocketUpgradeServiceValidator {
                             .equals(PluginConstants.ORG_NAME) && WebSocketConstants.PACKAGE_WEBSOCKET
                             .equals(symbol.getModule().map(ModuleSymbol::id).get().modulePrefix())) || (
                             symbol.typeKind() == TypeDescKind.TYPE_REFERENCE &&
-                                    ((TypeReferenceTypeSymbol) symbol).typeDescriptor() instanceof ErrorTypeSymbol))) {
+                                    ((TypeReferenceTypeSymbol) symbol).typeDescriptor().typeKind()
+                                            == TypeDescKind.ERROR))) {
                         Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RETURN_TYPES_IN_RESOURCE,
                                 resourceNode.location(), symbol.typeKind().getName(), resourceNode.functionName(),
                                 modulePrefix + PluginConstants.SERVICE + PluginConstants.PIPE + modulePrefix

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.websocket.plugin;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -43,7 +44,6 @@ import io.ballerina.stdlib.websocket.WebSocketConstants;
 import java.util.List;
 
 import static io.ballerina.stdlib.websocket.plugin.PluginConstants.REMOTE_KEY_WORD;
-import static io.ballerina.stdlib.websocket.plugin.Utils.ERROR;
 
 /**
  * Class to validate WebSocket services.
@@ -155,8 +155,8 @@ public class WebSocketUpgradeServiceValidator {
                             .equals(PluginConstants.SERVICE) && symbol.getModule().map(ModuleSymbol::id).get().orgName()
                             .equals(PluginConstants.ORG_NAME) && WebSocketConstants.PACKAGE_WEBSOCKET
                             .equals(symbol.getModule().map(ModuleSymbol::id).get().modulePrefix())) || (
-                            symbol.typeKind() == TypeDescKind.TYPE_REFERENCE && symbol.signature()
-                                    .contains(ERROR)))) {
+                            symbol.typeKind() == TypeDescKind.TYPE_REFERENCE &&
+                                    ((TypeReferenceTypeSymbol) symbol).typeDescriptor() instanceof ErrorTypeSymbol))) {
                         Utils.reportDiagnostics(ctx, PluginConstants.CompilationErrors.INVALID_RETURN_TYPES_IN_RESOURCE,
                                 resourceNode.location(), symbol.typeKind().getName(), resourceNode.functionName(),
                                 modulePrefix + PluginConstants.SERVICE + PluginConstants.PIPE + modulePrefix

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,7 +22,7 @@ project(':checkstyle').projectDir = file("build-config${File.separator}checkstyl
 project(':websocket-native').projectDir = file('native')
 project(':websocket-ballerina').projectDir = file('ballerina')
 project(':websocket-compiler-plugin').projectDir = file('compiler-plugin')
-project(':websocket-compiler-plugin-test').projectDir = file('compiler-plugin-test')
+project(':websocket-compiler-plugin-test').projectDir = file('compiler-plugin-tests')
 
 gradleEnterprise {
     buildScan {


### PR DESCRIPTION
## Purpose
Compiler plugin tests have been mistakenly opted out of the build during the migration. So this PR will re-enable them along with fixing the error type validation.
