### PR TITLE
Add OAuth2 JWT bearer grant type support for client

### DIFF
--- a/ballerina/auth_types.bal
+++ b/ballerina/auth_types.bal
@@ -64,8 +64,13 @@ public type OAuth2RefreshTokenGrantConfig record {|
     *oauth2:RefreshTokenGrantConfig;
 |};
 
+# Represents OAuth2 JWT bearer grant configurations for OAuth2 authentication.
+public type OAuth2JwtBearerGrantConfig record {|
+    *oauth2:JwtBearerGrantConfig;
+|};
+
 # Represents OAuth2 grant configurations for OAuth2 authentication.
-public type OAuth2GrantConfig OAuth2ClientCredentialsGrantConfig|OAuth2PasswordGrantConfig|OAuth2RefreshTokenGrantConfig;
+public type OAuth2GrantConfig OAuth2ClientCredentialsGrantConfig|OAuth2PasswordGrantConfig|OAuth2RefreshTokenGrantConfig|OAuth2JwtBearerGrantConfig;
 
 # Represents file user store configurations for Basic Auth authentication.
 public type FileUserStoreConfig record {|

--- a/ballerina/tests/auth_declarative_oauth2_test.bal
+++ b/ballerina/tests/auth_declarative_oauth2_test.bal
@@ -134,6 +134,33 @@ public function testOAuth2RefreshTokenGrantAuthSuccess() returns Error? {
     error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeout = 0);
 }
 
+@test:Config {
+    before: clear
+}
+public function testOAuth2JwtBearerGrantAuthSuccess() returns Error? {
+    Client wsClient = check new("ws://localhost:21325/oauthService/", {
+        auth: {
+            tokenUrl: "https://localhost:9445/oauth2/token",
+            assertion: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+            clientId: "3MVG9YDQS5WtC11paU2WcQjBB3L5w4gz52uriT8ksZ3nUVjKvrfQMrU4uvZohTftxStwNEW4cfStBEGRxRL68",
+            clientSecret: "9205371918321623741",
+            scopes: ["write", "update"],
+            clientConfig: {
+                secureSocket: {
+                   cert: {
+                       path: TRUSTSTORE_PATH,
+                       password: "ballerina"
+                   }
+                }
+            }
+        }
+    });
+    check wsClient->writeTextMessage("Hello, World!");
+    runtime:sleep(0.5);
+    test:assertEquals(wsService55Data, "Hello, World!");
+    error? result = wsClient->close(statusCode = 1000, reason = "Close the connection", timeout = 0);
+}
+
 function clear() {
     wsService55Data = "";
 }

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [Introduce write time out for WebSocket client](https://github.com/ballerina-platform/ballerina-standard-library/issues/1609)
+- [Add OAuth2 JWT bearer grant type support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1788)
 
 ## [1.2.0-beta.2] - 2021-07-07
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,6 @@ stdlibMimeVersion=2.0.0-20210816-151300-4328faf
 stdlibCacheVersion=3.0.0-20210816-151300-4bb5812
 stdlibAuthVersion=2.0.0-20210816-152100-c3cf8c7
 stdlibJwtVersion=2.0.0-20210816-152100-2d287f8
-stdlibOAuth2Version=2.0.0-20210816-152400-9bb2bdb
+stdlibOAuth2Version=2.0.0-20210817-153400-d6dec5e
 stdlibUuidVersion=1.0.0-20210816-151300-92124cc
 stdlibUrlVersion=2.0.0-20210816-124200-b84ece3


### PR DESCRIPTION
## Purpose
This PR adds OAuth2 JWT bearer grant type support for WebSocket client.

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1788

## Examples
```ballerina
import ballerina/io;
import ballerina/websocket;

websocket:Client securedEP = check new("wss://localhost:9090/foo/bar",
    auth = {
        tokenUrl: "https://localhost:9445/oauth2/token",
        assertion: "eyJhbGciOiJFUzI1NiIsImtpZCI6Ij[...omitted for brevity...]",
        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
        scopes: ["admin"],
        clientConfig: {
            secureSocket: {
                cert: "../resource/path/to/public.crt"
            }
        }
    },
    secureSocket = {
        cert: "../resource/path/to/public.crt"
    }
);

public function main() returns error? {
    check securedEP->writeTextMessage("Hello, World!");
    string textMessage = check securedEP->readTextMessage();
    io:println(textMessage);
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests