### PR TITLE
Fix compiler plugin error when returning `error` from `get` resource

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -40,9 +40,6 @@ version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "constraint", moduleName = "constraint"}
-]
 
 [[package]]
 org = "ballerina"
@@ -104,9 +101,6 @@ version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
-]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
 ]
 
 [[package]]
@@ -192,9 +186,6 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
-]
 
 [[package]]
 org = "ballerina"
@@ -203,9 +194,6 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
 ]
 
 [[package]]
@@ -298,18 +286,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "test"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "test", moduleName = "test"}
-]
-
-[[package]]
-org = "ballerina"
 name = "time"
 version = "2.2.3"
 dependencies = [
@@ -333,19 +309,14 @@ name = "websocket"
 version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
-	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.array"},
-	{org = "ballerina", name = "lang.runtime"},
-	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "oauth2"},
 	{org = "ballerina", name = "regex"},
-	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"}
 ]
 modules = [

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_56/server.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_56/server.bal
@@ -18,7 +18,7 @@ import ballerina/websocket;
 
 listener websocket:Listener localListener = new(8080);
 service / on localListener {
-   resource function get .() returns websocket:Service|websocket:Error {
+   resource function get .() returns websocket:Service|error {
        return new WsService();
    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
@@ -150,7 +150,8 @@ public class WebSocketUpgradeServiceValidator {
                     if (!((symbol.typeKind() == TypeDescKind.TYPE_REFERENCE && symbol.getName().get()
                             .equals(PluginConstants.SERVICE) && symbol.getModule().map(ModuleSymbol::id).get().orgName()
                             .equals(PluginConstants.ORG_NAME) && WebSocketConstants.PACKAGE_WEBSOCKET
-                            .equals(symbol.getModule().map(ModuleSymbol::id).get().modulePrefix())) || (
+                            .equals(symbol.getModule().map(ModuleSymbol::id).get().modulePrefix()) ||
+                            symbol.typeKind() == TypeDescKind.ERROR) || (
                             symbol.typeKind() == TypeDescKind.TYPE_REFERENCE &&
                                     ((TypeReferenceTypeSymbol) symbol).typeDescriptor().typeKind()
                                             == TypeDescKind.ERROR))) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3876

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [x] Added tests
- [ ] Checked native-image compatibility
