### PR TITLE
Fix compiler plugin error of returning `error` from `get` resource

### DIFF
--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_56/server.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_56/server.bal
@@ -18,7 +18,7 @@ import ballerina/websocket;
 
 listener websocket:Listener localListener = new(8080);
 service / on localListener {
-   resource function get .() returns websocket:Service|websocket:Error {
+   resource function get .() returns websocket:Service|error {
        return new WsService();
    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidator.java
@@ -150,7 +150,8 @@ public class WebSocketUpgradeServiceValidator {
                     if (!((symbol.typeKind() == TypeDescKind.TYPE_REFERENCE && symbol.getName().get()
                             .equals(PluginConstants.SERVICE) && symbol.getModule().map(ModuleSymbol::id).get().orgName()
                             .equals(PluginConstants.ORG_NAME) && WebSocketConstants.PACKAGE_WEBSOCKET
-                            .equals(symbol.getModule().map(ModuleSymbol::id).get().modulePrefix())) || (
+                            .equals(symbol.getModule().map(ModuleSymbol::id).get().modulePrefix()) ||
+                            symbol.typeKind() == TypeDescKind.ERROR) || (
                             symbol.typeKind() == TypeDescKind.TYPE_REFERENCE &&
                                     ((TypeReferenceTypeSymbol) symbol).typeDescriptor().typeKind()
                                             == TypeDescKind.ERROR))) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3876

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
