### PR TITLE
Fix the hanging issue when closing the connection while reading

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -204,6 +204,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
+]
 
 [[package]]
 org = "ballerina"
@@ -337,6 +340,7 @@ dependencies = [
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "oauth2"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,9 +41,6 @@ version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "constraint", moduleName = "constraint"}
-]
 
 [[package]]
 org = "ballerina"
@@ -207,9 +204,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.regexp"}
 ]
-modules = [
-	{org = "ballerina", packageName = "lang.string", moduleName = "lang.string"}
-]
 
 [[package]]
 org = "ballerina"
@@ -337,14 +331,12 @@ name = "websocket"
 version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
-	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.runtime"},
-	{org = "ballerina", name = "lang.string"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "oauth2"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -192,9 +192,6 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
-]
 
 [[package]]
 org = "ballerina"
@@ -336,7 +333,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.array"},
-	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "oauth2"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -192,6 +192,9 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
 
 [[package]]
 org = "ballerina"
@@ -273,7 +276,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -333,6 +336,7 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.runtime"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "oauth2"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,6 +41,9 @@ version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "constraint", moduleName = "constraint"}
+]
 
 [[package]]
 org = "ballerina"
@@ -334,6 +337,7 @@ name = "websocket"
 version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
+	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/tests/test_close_while_reading.bal
+++ b/ballerina/tests/test_close_while_reading.bal
@@ -28,7 +28,7 @@ service /textstring on l6191 {
 // Does not send any data to the client.
 service class ParallelReadService {
     *Service;
-    remote function onClose(Caller caller) returns error? {
+    remote function onClose(Caller caller) {
         io:println(string `Connection ${caller.getConnectionId()} closed`);
     }
 }

--- a/ballerina/tests/test_close_while_reading.bal
+++ b/ballerina/tests/test_close_while_reading.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 WSO2 LLC. (//www.wso2.org) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/test;
+import ballerina/lang.runtime;
+
+service /textstring on new Listener(6091) {
+    resource function get .() returns ParallelReadService {
+        return new ParallelReadService();
+    }
+}
+
+// Does not send any data to the client.
+service class ParallelReadService {
+    *Service;
+    remote function onClose(Caller caller) returns error? {
+        io:println(string `Connection ${caller.getConnectionId()} closed`);
+    }
+}
+
+@test:Config {}
+public function testParallelClosure() returns Error? {
+    Client ws = check new ("ws://localhost:6091/textstring");
+    json request = {'type: "start"};
+    check ws->writeMessage(request);
+
+    worker name returns error? {
+        while true {
+            json data = check ws->readMessage();
+        } 
+    }
+    // wait for the worker to start and block in the read operation.
+    runtime:sleep(5);
+    error? err =  ws->close(timeout = 3); // close the connection during the communication
+}

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - [Fix dispatching failure when a `-` is used in the service path](https://github.com/ballerina-platform/ballerina-standard-library/issues/4320)
+- [Fix the hanging issue when closing the connection while reading the message](https://github.com/ballerina-platform/ballerina-standard-library/issues/3962)
 
 ## [2.6.0] - 2023-02-27
 

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
@@ -136,6 +136,8 @@ public class WebSocketConstants {
     public static final String BALLERINA_HTTP_HEADER = ModuleUtils.getHttpPackageIdentifier() + COLON + ANN_NAME_HEADER;
     public static final String PATH_PARAM_IDENTIFIER = "^";
     public static final String STREAMING_NEXT_FUNCTION = "next";
+    public static final String CONNECTION_CLOSED = "Connection closed";
+    public static final String STATUS_CODE = "Status code:";
 
     private WebSocketConstants() {
     }

--- a/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/WebSocketSyncConnector.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/WebSocketSyncConnector.java
@@ -46,6 +46,7 @@ public class WebSocketSyncConnector {
             throws IllegalAccessException {
         WebSocketConnectionInfo connectionInfo = (WebSocketConnectionInfo) wsConnection
                 .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
+        connectionInfo.addCallback(callback);
         if (!connectionInfo.getWebSocketConnection().isOpen()) {
             callback.complete(WebSocketUtil.createWebsocketError("Connection already closed",
                             WebSocketConstants.ErrorCode.ConnectionClosureError));

--- a/native/src/main/java/io/ballerina/stdlib/websocket/client/listener/SyncClientConnectorListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/client/listener/SyncClientConnectorListener.java
@@ -125,6 +125,7 @@ public class SyncClientConnectorListener implements WebSocketConnectorListener {
                         callback.complete(message);
                     }
                     futureCompleted.set(true);
+                    connectionInfo.getCallbacks().remove(callback);
                 }
                 connectionInfo.getWebSocketConnection().removeReadIdleStateHandler();
             } else {
@@ -300,6 +301,12 @@ public class SyncClientConnectorListener implements WebSocketConnectorListener {
     @Override
     public void onClose(WebSocketConnection webSocketConnection) {
         WebSocketObservabilityUtil.observeClose(connectionInfo);
+        if (connectionInfo.getCallbacks().size() > 0) {
+            connectionInfo.getCallbacks().forEach(callback -> {
+                callback.complete(WebSocketUtil.createWebsocketError("Connection closed",
+                                WebSocketConstants.ErrorCode.ConnectionClosureError));
+            });
+        }
         try {
             WebSocketUtil.setListenerOpenField(connectionInfo);
         } catch (IllegalAccessException e) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/client/listener/SyncClientConnectorListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/client/listener/SyncClientConnectorListener.java
@@ -240,8 +240,10 @@ public class SyncClientConnectorListener implements WebSocketConnectorListener {
                 int closeCode = webSocketCloseMessage.getCloseCode();
                 String closeReason = webSocketCloseMessage.getCloseReason() == null ||
                         webSocketCloseMessage.getCloseReason().equals("") ?
-                        "Connection closed: Status code: " + closeCode :
-                        webSocketCloseMessage.getCloseReason() + ": Status code: " + closeCode;
+                        String.format("%s %s %d", WebSocketConstants.CONNECTION_CLOSED,
+                                WebSocketConstants.STATUS_CODE, closeCode) :
+                        String.format("%s: %s %d", webSocketCloseMessage.getCloseReason(),
+                                WebSocketConstants.STATUS_CODE, closeCode);
                 if (WebSocketUtil.hasRetryConfig(connectionInfo.getWebSocketEndpoint())) {
                     if (closeCode == WebSocketConstants.STATUS_CODE_ABNORMAL_CLOSURE &&
                             WebSocketUtil.reconnect(connectionInfo, callback, futureCompleted)) {
@@ -264,7 +266,7 @@ public class SyncClientConnectorListener implements WebSocketConnectorListener {
                 WebSocketResourceDispatcher.finishConnectionClosureIfOpen(wsConnection, closeCode, connectionInfo);
                 if (connectionInfo.getCallbacks().size() > 0) {
                     connectionInfo.getCallbacks().forEach(callback -> {
-                        callback.complete(WebSocketUtil.createWebsocketError("Connection closed",
+                        callback.complete(WebSocketUtil.createWebsocketError(WebSocketConstants.CONNECTION_CLOSED,
                                 WebSocketConstants.ErrorCode.ConnectionClosureError));
                     });
                 }
@@ -310,7 +312,7 @@ public class SyncClientConnectorListener implements WebSocketConnectorListener {
         WebSocketObservabilityUtil.observeClose(connectionInfo);
         if (connectionInfo.getCallbacks().size() > 0) {
             connectionInfo.getCallbacks().forEach(callback -> {
-                callback.complete(WebSocketUtil.createWebsocketError("Connection closed",
+                callback.complete(WebSocketUtil.createWebsocketError(WebSocketConstants.CONNECTION_CLOSED,
                                 WebSocketConstants.ErrorCode.ConnectionClosureError));
             });
         }

--- a/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketConnectionInfo.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketConnectionInfo.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.websocket.server;
 
+import io.ballerina.runtime.api.Future;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.stdlib.http.transport.contract.websocket.WebSocketConnection;
 import io.ballerina.stdlib.websocket.WebSocketConstants;
@@ -25,6 +26,8 @@ import io.ballerina.stdlib.websocket.WebSocketService;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class has WebSocket connection info for both the client and the server. Includes details
@@ -37,6 +40,7 @@ public class WebSocketConnectionInfo {
     private final WebSocketConnection webSocketConnection;
     private StringAggregator stringAggregator = null;
     private ByteArrAggregator byteArrAggregator = null;
+    private List<Future> callbacks = new ArrayList<>();
 
     /**
      * @param webSocketService    can be the WebSocketServerService or WebSocketService
@@ -128,5 +132,13 @@ public class WebSocketConnectionInfo {
         public void resetAggregateByteArr() {
             this.aggregateArr = new ByteArrayOutputStream();
         }
+    }
+
+    public void addCallback(Future callback) {
+        callbacks.add(callback);
+    }
+
+    public List<Future> getCallbacks() {
+        return callbacks;
     }
 }


### PR DESCRIPTION
## Purpose

This PR fixes the hanging issue when one strand is used to read messages and another is used to close the connection. The reason for this is close operation does not complete the readMessage future. So it waits until a message comes. 

Fixes the issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/3962

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [x] Added tests
- [ ] Checked native-image compatibility
