### PR TITLE
Add `connectionClosureTimeout` service config annotation

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -22,19 +22,19 @@ path = "../native/build/libs/websocket-native-2.14.0-SNAPSHOT.jar"
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
 version = "2.14.0"
-path = "./lib/http-native-2.14.0-20250305-195600-c559baa.jar"
+path = "./lib/http-native-2.14.0-20250311-152000-c0b9408.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mime-native"
 version = "2.12.0"
-path = "./lib/mime-native-2.12.0-20250305-174800-8528404.jar"
+path = "./lib/mime-native-2.12.0-20250311-141300-98bc7d6.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
 version = "1.7.0"
-path = "./lib/constraint-native-1.7.0-20250305-165400-52275bd.jar"
+path = "./lib/constraint-native-1.7.0-20250311-133400-acfb095.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -22,20 +22,19 @@ path = "../native/build/libs/websocket-native-2.14.1-SNAPSHOT.jar"
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
 version = "2.14.0"
-path = "./lib/http-native-2.14.0-20250311-152000-c0b9408.jar"
-
+path = "./lib/http-native-2.14.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "mime-native"
 version = "2.12.0"
-path = "./lib/mime-native-2.12.0-20250311-141300-98bc7d6.jar"
+path = "./lib/mime-native-2.12.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
 version = "1.7.0"
-path = "./lib/constraint-native-1.7.0-20250311-133400-acfb095.jar"
+path = "./lib/constraint-native-1.7.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websocket"
-version = "2.14.1"
+version = "2.15.0"
 authors = ["Ballerina"]
 keywords = ["ws", "network", "bi-directional", "streaming", "service", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websocket"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "websocket-native"
-version = "2.14.1"
-path = "../native/build/libs/websocket-native-2.14.1-SNAPSHOT.jar"
+version = "2.15.0"
+path = "../native/build/libs/websocket-native-2.15.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
@@ -85,5 +85,5 @@ version = "4.1.118.Final"
 path = "./lib/netty-handler-proxy-4.1.118.Final.jar"
 
 [[platform.java21.dependency]]
-path = "../test-utils/build/libs/websocket-test-utils-2.14.1-SNAPSHOT.jar"
+path = "../test-utils/build/libs/websocket-test-utils-2.15.0-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "websocket-compiler-plugin"
 class = "io.ballerina.stdlib.websocket.plugin.WebSocketCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websocket-compiler-plugin-2.14.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/websocket-compiler-plugin-2.15.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0-20250228-201300-8d411a0f"
+distribution-version = "2201.12.0-20250311-124800-b9003fed"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -342,7 +342,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.14.1"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,8 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0-20250311-124800-b9003fed"
-
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/annotation.bal
+++ b/ballerina/annotation.bal
@@ -32,9 +32,9 @@
 # + dispatcherStreamId - The identifier used to distinguish between requests and their corresponding responses in a multiplexing scenario.
 # + connectionClosureTimeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint 
 # before closing the connection. If the timeout exceeds, then the connection is terminated even though a close frame is
-# not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits until a close frame is
-# received. If the WebSocket frame is received from the remote endpoint within the waiting period, the connection is
-# terminated immediately.
+# not received from the remote endpoint. If the value is -1, then the connection waits until a close frame is
+# received, and any other negative value results in an error. If the WebSocket frame is received from the remote endpoint
+# within the waiting period, the connection is terminated immediately.
 public type WSServiceConfig record {|
     string[] subProtocols = [];
     decimal idleTimeout = 0;

--- a/ballerina/annotation.bal
+++ b/ballerina/annotation.bal
@@ -30,11 +30,11 @@
 # + validation - Enable/disable constraint validation
 # + dispatcherKey - The key which is going to be used for dispatching to custom remote functions.
 # + dispatcherStreamId - The identifier used to distinguish between requests and their corresponding responses in a multiplexing scenario.
-# + connectionClosureTimeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint before closing the
-# connection. If the timeout exceeds, then the connection is terminated even though a close frame
-# is not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits
-# until a close frame is received. If the WebSocket frame is received from the remote endpoint
-# within the waiting period, the connection is terminated immediately.
+# + connectionClosureTimeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint 
+# before closing the connection. If the timeout exceeds, then the connection is terminated even though a close frame is
+# not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits until a close frame is
+# received. If the WebSocket frame is received from the remote endpoint within the waiting period, the connection is
+# terminated immediately.
 public type WSServiceConfig record {|
     string[] subProtocols = [];
     decimal idleTimeout = 0;

--- a/ballerina/annotation.bal
+++ b/ballerina/annotation.bal
@@ -22,14 +22,19 @@
 #
 # + subProtocols - Negotiable sub protocol by the service
 # + idleTimeout - Idle timeout for the client connection. Upon timeout, `onIdleTimeout` resource (if defined)
-#   in the server service will be triggered. Note that this overrides the `timeout` config
-#   in the `websocket:Listener`, which is applicable only for the initial HTTP upgrade request
+# in the server service will be triggered. Note that this overrides the `timeout` config
+# in the `websocket:Listener`, which is applicable only for the initial HTTP upgrade request
 # + maxFrameSize - The maximum payload size of a WebSocket frame in bytes.
-#   If this is not set or is negative or zero, the default frame size, which is 65536 will be used
+# If this is not set or is negative or zero, the default frame size, which is 65536 will be used
 # + auth - Listener authentication configurations
 # + validation - Enable/disable constraint validation
 # + dispatcherKey - The key which is going to be used for dispatching to custom remote functions.
 # + dispatcherStreamId - The identifier used to distinguish between requests and their corresponding responses in a multiplexing scenario.
+# + connectionClosureTimeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint before closing the
+# connection. If the timeout exceeds, then the connection is terminated even though a close frame
+# is not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits
+# until a close frame is received. If the WebSocket frame is received from the remote endpoint
+# within the waiting period, the connection is terminated immediately.
 public type WSServiceConfig record {|
     string[] subProtocols = [];
     decimal idleTimeout = 0;
@@ -38,6 +43,7 @@ public type WSServiceConfig record {|
     boolean validation = true;
     string dispatcherKey?;
     string dispatcherStreamId?;
+    decimal connectionClosureTimeout = 60;
 |};
 
 # The annotation which is used to configure a WebSocket service.

--- a/ballerina/tests/connection_closure_timeout.bal
+++ b/ballerina/tests/connection_closure_timeout.bal
@@ -113,9 +113,21 @@ public function testConnectionClosureTimeoutCallerNegativeTimeout() returns erro
 }
 public function testConnectionClosureTimeoutNegativeValueInClient() returns error? {
     Client wsClient1 = check new ("ws://localhost:22100/");
-    Error? close = wsClient1->close(timeout = -10);
+    Error? close = wsClient1->close(timeout = -20);
     test:assertTrue(close is error);
     if close is error {
-        test:assertEquals(close.message(), "Invalid timeout value: -10");
+        test:assertEquals(close.message(), "Invalid timeout value: -20");
+    }
+}
+
+@test:Config {
+    groups: ["connectionClosureTimeout","test"]
+}
+public function testInvalidConnectionClosureTimeoutValue() returns error? {
+    Client wsClient1 = check new ("ws://localhost:22100/");
+    Error? close = wsClient1->close(timeout = 200000000000000000);
+    test:assertTrue(close is error);
+    if close is error {
+        test:assertEquals(close.message(), "Error: Invalid timeout value: 200000000000000000");
     }
 }

--- a/ballerina/tests/connection_closure_timeout.bal
+++ b/ballerina/tests/connection_closure_timeout.bal
@@ -107,3 +107,15 @@ public function testConnectionClosureTimeoutCallerNegativeTimeout() returns erro
     string errorMessage = check wsClient2->readMessage();
     test:assertEquals(errorMessage, "Invalid timeout value: -10");
 }
+
+@test:Config {
+    groups: ["connectionClosureTimeout"]
+}
+public function testConnectionClosureTimeoutNegativeValueInClient() returns error? {
+    Client wsClient1 = check new ("ws://localhost:22100/");
+    Error? close = wsClient1->close(timeout = -10);
+    test:assertTrue(close is error);
+    if close is error {
+        test:assertEquals(close.message(), "Invalid timeout value: -10");
+    }
+}

--- a/ballerina/tests/connection_closure_timeout.bal
+++ b/ballerina/tests/connection_closure_timeout.bal
@@ -1,0 +1,50 @@
+//  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.org).
+//
+//  WSO2 LLC. licenses this file to you under the Apache License,
+//  Version 2.0 (the "License"); you may not use this file except
+//  in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+import ballerina/lang.runtime;
+import ballerina/test;
+
+listener Listener connectionClosureTimeoutListener = new (22100);
+
+@ServiceConfig {
+    connectionClosureTimeout: 10
+}
+service / on connectionClosureTimeoutListener {
+    resource function get .() returns Service|UpgradeError {
+        return new ConnectionClosureTimeoutService();
+    }
+}
+
+service class ConnectionClosureTimeoutService {
+    *Service;
+
+    remote function onMessage(Caller caller, string data) returns error? {
+        _ = start caller->close();
+        runtime:sleep(1);
+        test:assertTrue(caller.isOpen());
+        runtime:sleep(10);
+        test:assertTrue(!caller.isOpen());
+    }
+}
+
+@test:Config {
+    groups: ["connectionClosureTimeout"]
+}
+public function testConnectionClosureTimeoutFromServer() returns Error? {
+    Client wsClient = check new ("ws://localhost:22100/");
+    check wsClient->writeMessage("Hi");
+    runtime:sleep(20);
+}

--- a/ballerina/websocket_caller.bal
+++ b/ballerina/websocket_caller.bal
@@ -98,7 +98,7 @@ public isolated client class Caller {
             }
             code = statusCode;
         }
-        if (timeout is decimal && timeout < 0d && timeout != -1d) {
+        if timeout is decimal && timeout < 0d && timeout != -1d {
             string errorMessage = "Invalid timeout value: " + timeout.toString();
             return error Error(errorMessage);
         }

--- a/ballerina/websocket_caller.bal
+++ b/ballerina/websocket_caller.bal
@@ -88,7 +88,7 @@ public isolated client class Caller {
     # within the waiting period, the connection is terminated immediately
     # + return - A `websocket:Error` if an error occurs when sending
     remote isolated function close(int? statusCode = 1000, string? reason = (),
-        decimal timeout = 60) returns Error? {
+        decimal? timeout = ()) returns Error? {
         int code = 1000;
         if (statusCode is int) {
             if (statusCode <= 999 || statusCode >= 1004 && statusCode <= 1006 || statusCode >= 1012 &&
@@ -101,7 +101,7 @@ public isolated client class Caller {
         return self.externClose(code, reason is () ? "" : reason, timeout);
     }
 
-    isolated function externClose(int statusCode, string reason, decimal timeoutInSecs) returns Error? = @java:Method {
+    isolated function externClose(int statusCode, string reason, decimal? timeoutInSecs = ()) returns Error? = @java:Method {
         'class: "io.ballerina.stdlib.websocket.actions.websocketconnector.Close"
     } external;
 

--- a/ballerina/websocket_caller.bal
+++ b/ballerina/websocket_caller.bal
@@ -83,9 +83,9 @@ public isolated client class Caller {
     # + reason - Reason for closing the connection
     # + timeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint before closing the
     # connection. If the timeout exceeds, then the connection is terminated even though a close frame
-    # is not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits
-    # until a close frame is received. If the WebSocket frame is received from the remote endpoint
-    # within the waiting period, the connection is terminated immediately
+    # is not received from the remote endpoint. If the value is -1, then the connection waits
+    # until a close frame is received, and any other negative value results in an error. If the WebSocket frame is received
+    # from the remote endpoint within the waiting period, the connection is terminated immediately
     # + return - A `websocket:Error` if an error occurs when sending
     remote isolated function close(int? statusCode = 1000, string? reason = (),
         decimal? timeout = ()) returns Error? {
@@ -97,6 +97,10 @@ public isolated client class Caller {
                 return error ConnectionClosureError(errorMessage);
             }
             code = statusCode;
+        }
+        if (timeout is decimal && timeout < 0d && timeout != -1d) {
+            string errorMessage = "Invalid timeout value: " + timeout.toString();
+            return error Error(errorMessage);
         }
         return self.externClose(code, reason is () ? "" : reason, timeout);
     }

--- a/ballerina/websocket_sync_client.bal
+++ b/ballerina/websocket_sync_client.bal
@@ -120,7 +120,7 @@ public isolated client class Client {
             }
             code = statusCode;
         }
-        if (timeout < 0d && timeout != -1d) {
+        if timeout < 0d && timeout != -1d {
             string errorMessage = "Invalid timeout value: " + timeout.toString();
             return error Error(errorMessage);
         }

--- a/ballerina/websocket_sync_client.bal
+++ b/ballerina/websocket_sync_client.bal
@@ -105,9 +105,10 @@ public isolated client class Client {
     # + reason - Reason for closing the connection
     # + timeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint before closing the
     # connection. If the timeout exceeds, then the connection is terminated even though a close frame
-    # is not received from the remote endpoint. If the value is < 0 (e.g., -1), then the connection
-    # waits until a close frame is received. If the WebSocket frame is received from the remote
-    # endpoint within the waiting period, the connection is terminated immediately
+    # is not received from the remote endpoint. If the value is -1, then the connection
+    # waits until a close frame is received, and any other negative value results in an error.
+    # If the WebSocket frame is received from the remote endpoint within the waiting period,
+    # the connection is terminated immediately
     # + return - A `websocket:Error` if an error occurs while closing the WebSocket connection
     remote isolated function close(int? statusCode = 1000, string? reason = (), decimal timeout = 60) returns Error? {
         int code = 1000;
@@ -118,6 +119,10 @@ public isolated client class Client {
                 return error ConnectionClosureError(errorMessage);
             }
             code = statusCode;
+        }
+        if (timeout < 0d && timeout != -1d) {
+            string errorMessage = "Invalid timeout value: " + timeout.toString();
+            return error Error(errorMessage);
         }
         return self.externClose(code, reason is () ? "" : reason, timeout);
     }

--- a/ballerina/websocket_sync_client.bal
+++ b/ballerina/websocket_sync_client.bal
@@ -226,7 +226,7 @@ public isolated client class Client {
         }
     }
 
-    isolated function externClose(int statusCode, string reason, decimal timeoutInSecs)
+    isolated function externClose(int statusCode, string reason, decimal? timeoutInSecs)
                          returns Error? = @java:Method {
         'class: "io.ballerina.stdlib.websocket.actions.websocketconnector.Close"
     } external;

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- [Introduce Service Config Annotation for connectionClosureTimeout in Websocket module](https://github.com/ballerina-platform/ballerina-library/issues/7697)
+
 ### Fixed
 
 - [Fix JSON response parsing issue with escaped double quotes](https://github.com/ballerina-platform/ballerina-library/issues/7720)

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websocket/compiler/WebSocketServiceValidationTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/websocket/compiler/WebSocketServiceValidationTest.java
@@ -572,6 +572,16 @@ public class WebSocketServiceValidationTest {
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
     }
 
+    @Test
+    public void testConnectionClosureTimeoutInTheServiceConfig() {
+        Package currentPackage = loadPackage("sample_package_64");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errorCount(), 1);
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[0];
+        assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_CONNECTION_CLOSURE_TIMEOUT);
+    }
+
     private void assertDiagnostic(Diagnostic diagnostic, PluginConstants.CompilationErrors error) {
         Assert.assertEquals(diagnostic.diagnosticInfo().code(), error.getErrorCode());
         Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_64/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_64/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "websocket_test"
+name = "sample_64"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_64/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_64/service.bal
@@ -1,0 +1,30 @@
+//  Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+//
+//  WSO2 LLC. licenses this file to you under the Apache License,
+//  Version 2.0 (the "License"); you may not use this file except
+//  in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied. See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
+import ballerina/websocket;
+
+@websocket:ServiceConfig {
+    connectionClosureTimeout: -5
+}
+service / on new websocket:Listener(9090) {
+    resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
+        return new WsService();
+    }
+}
+
+service isolated class WsService {
+    *websocket:Service;
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_64/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_64/service.bal
@@ -28,3 +28,24 @@ service / on new websocket:Listener(9090) {
 service isolated class WsService {
     *websocket:Service;
 }
+
+// We ignore the compiler validation for below services since value is provided via a variable
+decimal connectionClosureTimeout = 5.0;
+
+@websocket:ServiceConfig {
+    connectionClosureTimeout: connectionClosureTimeout
+}
+service / on new websocket:Listener(9090) {
+    resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
+        return new WsService();
+    }
+}
+
+@websocket:ServiceConfig {
+    connectionClosureTimeout
+}
+service / on new websocket:Listener(9090) {
+    resource isolated function get .() returns websocket:Service|websocket:UpgradeError {
+        return new WsService();
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/PluginConstants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/PluginConstants.java
@@ -105,7 +105,9 @@ public class PluginConstants {
         CONTRADICTING_RETURN_TYPES("Contradicting return types provided for `{0}` remote function, cannot contain" +
                 " stream type with other types", "WEBSOCKET_119"),
         DISPATCHER_STREAM_ID_WITHOUT_KEY("The `dispatcherStreamId` annotation is used without `dispatcherKey` " +
-                "annotation", "WEBSOCKET_120");
+                "annotation", "WEBSOCKET_120"),
+        INVALID_CONNECTION_CLOSURE_TIMEOUT("Invalid connection closure timeout provided for the service",
+                "WEBSOCKET_121");
 
         private final String error;
         private final String errorCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
@@ -116,11 +116,10 @@ public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<Syntax
 
     private boolean getDispatcherConfigAnnotation(ServiceDeclarationNode serviceNode,
                                                   SemanticModel semanticModel, String annotationName) {
-        Optional<MetadataNode> metadata = serviceNode.metadata();
-        if (metadata.isEmpty()) {
+        if (serviceNode.metadata().isEmpty()) {
             return false;
         }
-        MetadataNode metaData = metadata.get();
+        MetadataNode metaData = serviceNode.metadata().get();
         NodeList<AnnotationNode> annotations = metaData.annotations();
         return annotations.stream()
                 .anyMatch(ann -> isAnnotationPresent(ann, semanticModel, annotationName));
@@ -128,12 +127,10 @@ public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<Syntax
 
     private Optional<Double> getConnectionClosureTimeoutValue(ServiceDeclarationNode serviceNode,
                                                               SemanticModel semanticModel) {
-        Optional<MetadataNode> metadata = serviceNode.metadata();
-        if (metadata.isEmpty()) {
+        if (serviceNode.metadata().isEmpty()) {
             return Optional.empty();
         }
-        MetadataNode metaData = metadata.get();
-        NodeList<AnnotationNode> annotations = metaData.annotations();
+        NodeList<AnnotationNode> annotations = serviceNode.metadata().get().annotations();
         return annotations.stream()
                 .filter(ann -> isAnnotationPresent(ann, semanticModel, ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT))
                 .map(ann -> getAnnotationValue(ann, ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT))

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
@@ -146,7 +146,7 @@ public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<Syntax
             return Optional.empty();
         }
         for (MappingFieldNode field : annotation.annotValue().get().fields()) {
-            if (field.kind().equals(SyntaxKind.SPECIFIC_FIELD)) {
+            if (field.kind() == SyntaxKind.SPECIFIC_FIELD) {
                 SpecificFieldNode specificFieldNode = (SpecificFieldNode) field;
                 Optional<Symbol> symbol = semanticModel.symbol(specificFieldNode);
                 if (symbol.isEmpty()) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/websocket/plugin/WebSocketUpgradeServiceValidatorTask.java
@@ -146,7 +146,8 @@ public class WebSocketUpgradeServiceValidatorTask implements AnalysisTask<Syntax
             return Optional.empty();
         }
         for (MappingFieldNode field : annotation.annotValue().get().fields()) {
-            if (field instanceof SpecificFieldNode specificFieldNode) {
+            if (field.kind().equals(SyntaxKind.SPECIFIC_FIELD)) {
+                SpecificFieldNode specificFieldNode = (SpecificFieldNode) field;
                 Optional<Symbol> symbol = semanticModel.symbol(specificFieldNode);
                 if (symbol.isEmpty()) {
                     continue;

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -219,8 +219,8 @@ When writing the service, following configurations can be provided,
 # + dispatcherStreamId - The identifier used to distinguish between requests and their corresponding responses in a multiplexing scenario.
 # + connectionClosureTimeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint 
 # before closing the connection. If the timeout exceeds, then the connection is terminated even though a close frame is
-# not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits until a close frame is
-# received. If the WebSocket frame is received from the remote endpoint within the waiting period, the connection is
+# not received from the remote endpoint. If the value is -1, then the connection waits until a close frame is
+# received, and any other negative value results in an error. If the WebSocket frame is received from the remote endpoint within the waiting period, the connection is
 # terminated immediately.
 public type WSServiceConfig record {|
     string[] subProtocols = [];

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -234,6 +234,8 @@ public type WSServiceConfig record {|
 |};
 ```
 
+> **Note:** The `connectionClosureTimeout` is validated at compile-time for literal values and at runtime for non-literal values such as variables.
+
 ### 3.2. [WebSocket Service](#32-websocket-service)
 
 Once the WebSocket upgrade is accepted by the UpgradeService, it returns a `websocket:Service`. This service has a fixed set of remote methods that do not have any configs. Receiving messages will get dispatched to the relevant remote method. Each remote method is explained below.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -216,6 +216,11 @@ When writing the service, following configurations can be provided,
 # + auth - Listener authenticaton configurations
 # + dispatcherKey - The key which is going to be used for dispatching to custom remote functions.
 # + dispatcherStreamId - The identifier used to distinguish between requests and their corresponding responses in a multiplexing scenario.
+# + connectionClosureTimeout - Time to wait (in seconds) for the close frame to be received from the remote endpoint 
+# before closing the connection. If the timeout exceeds, then the connection is terminated even though a close frame is
+# not received from the remote endpoint. If the value < 0 (e.g., -1), then the connection waits until a close frame is
+# received. If the WebSocket frame is received from the remote endpoint within the waiting period, the connection is
+# terminated immediately.
 public type WSServiceConfig record {|
     string[] subProtocols = [];
     decimal idleTimeout = 0;
@@ -224,6 +229,7 @@ public type WSServiceConfig record {|
     boolean validation = true;
     string dispatcherKey?;
     string dispatcherStreamId?;
+    decimal connectionClosureTimeout = 60;
 |};
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.14.1-SNAPSHOT
+version=2.15.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 ballerinaTomlParserVersion=1.2.2
 nettyVersion=4.1.118.Final

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
@@ -115,6 +115,7 @@ public class WebSocketConstants {
     public static final int STATUS_CODE_FOR_NO_STATUS_CODE_PRESENT = 1005;
 
     public static final int DEFAULT_MAX_FRAME_SIZE = 65536;
+    public static final int DEFAULT_CONNECTION_CLOSURE_TIMEOUT  = 60;
 
     // Warning suppression
     public static final String UNCHECKED = "unchecked";

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
@@ -45,6 +45,8 @@ public class WebSocketConstants {
     public static final String WEBSOCKET_ANNOTATION_CONFIGURATION = "ServiceConfig";
     public static final BString ANNOTATION_ATTR_SUB_PROTOCOLS = StringUtils.fromString("subProtocols");
     public static final BString ANNOTATION_ATTR_IDLE_TIMEOUT = StringUtils.fromString("idleTimeout");
+    public static final BString ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT =
+            StringUtils.fromString("connectionClosureTimeout");
     public static final BString ANNOTATION_ATTR_READ_IDLE_TIMEOUT = StringUtils.fromString("readTimeout");
     public static final BString ANNOTATION_ATTR_TIMEOUT = StringUtils.fromString("timeout");
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
@@ -45,8 +45,7 @@ public class WebSocketConstants {
     public static final String WEBSOCKET_ANNOTATION_CONFIGURATION = "ServiceConfig";
     public static final BString ANNOTATION_ATTR_SUB_PROTOCOLS = StringUtils.fromString("subProtocols");
     public static final BString ANNOTATION_ATTR_IDLE_TIMEOUT = StringUtils.fromString("idleTimeout");
-    public static final BString ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT =
-            StringUtils.fromString("connectionClosureTimeout");
+    public static final String ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT = "connectionClosureTimeout";
     public static final BString ANNOTATION_ATTR_READ_IDLE_TIMEOUT = StringUtils.fromString("readTimeout");
     public static final BString ANNOTATION_ATTR_TIMEOUT = StringUtils.fromString("timeout");
     public static final BString ANNOTATION_ATTR_MAX_FRAME_SIZE = StringUtils.fromString("maxFrameSize");

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
@@ -148,7 +148,6 @@ public class WebSocketConstants {
     public static final BString CLOSE_FRAME_REASON = StringUtils.fromString("reason");
     public static final String PREDEFINED_CLOSE_FRAME_TYPE = "PredefinedCloseFrameType";
     public static final String CUSTOM_CLOSE_FRAME_TYPE = "CustomCloseFrameType";
-    public static final int CLOSE_FRAME_DEFAULT_TIMEOUT = 60;
 
     private WebSocketConstants() {
     }

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketConstants.java
@@ -115,7 +115,6 @@ public class WebSocketConstants {
     public static final int STATUS_CODE_FOR_NO_STATUS_CODE_PRESENT = 1005;
 
     public static final int DEFAULT_MAX_FRAME_SIZE = 65536;
-    public static final int DEFAULT_CONNECTION_CLOSURE_TIMEOUT  = 60;
 
     // Warning suppression
     public static final String UNCHECKED = "unchecked";

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketResourceCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketResourceCallback.java
@@ -48,11 +48,11 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static io.ballerina.runtime.api.utils.StringUtils.fromString;
-import static io.ballerina.stdlib.websocket.WebSocketConstants.CLOSE_FRAME_DEFAULT_TIMEOUT;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.CLOSE_FRAME_TYPE;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.PACKAGE_WEBSOCKET;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.STREAMING_NEXT_FUNCTION;
 import static io.ballerina.stdlib.websocket.WebSocketResourceDispatcher.dispatchOnError;
+import static io.ballerina.stdlib.websocket.actions.websocketconnector.Close.getConnectionClosureTimeout;
 import static io.ballerina.stdlib.websocket.actions.websocketconnector.Close.initiateConnectionClosure;
 import static io.ballerina.stdlib.websocket.actions.websocketconnector.Close.waitForTimeout;
 import static io.ballerina.stdlib.websocket.actions.websocketconnector.WebSocketConnector.fromByteArray;
@@ -152,7 +152,8 @@ public final class WebSocketResourceCallback implements Handler {
                 ChannelFuture closeFuture = initiateConnectionClosure(errors, statusCode, reason,
                         connectionInfo, countDownLatch);
                 connectionInfo.getWebSocketConnection().readNextFrame();
-                waitForTimeout(errors, CLOSE_FRAME_DEFAULT_TIMEOUT, countDownLatch, connectionInfo);
+                int timeoutInSecs = getConnectionClosureTimeout(null, connectionInfo);
+                waitForTimeout(errors, timeoutInSecs, countDownLatch, connectionInfo);
                 closeFuture.channel().close().addListener(future -> {
                     WebSocketUtil.setListenerOpenField(connectionInfo);
                 });

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
@@ -200,6 +200,16 @@ public class WebSocketUtil {
 
     }
 
+    public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key) {
+        try {
+            return (int) ((BDecimal) config.get(key)).floatValue();
+        } catch (Exception e) {
+            logger.warn("The value set for " + key + " is not a valid integer. The " + key + " value is set to " +
+                    Integer.MAX_VALUE);
+            return Integer.MAX_VALUE;
+        }
+    }
+
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key, int defaultValue) {
         try {
             int timeout = (int) ((BDecimal) config.get(key)).floatValue();

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
@@ -201,7 +201,13 @@ public class WebSocketUtil {
     }
 
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key) {
-        return (int) ((BDecimal) config.get(key)).floatValue();
+        try {
+            return (int) ((BDecimal) config.get(key)).floatValue();
+        } catch (ArithmeticException e) {
+            logger.warn("The value set for {} needs to be less than {} .The {} value is set to {} ", key,
+                    Integer.MAX_VALUE, key, Integer.MAX_VALUE);
+            return Integer.MAX_VALUE;
+        }
     }
 
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key, int defaultValue) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
@@ -201,13 +201,7 @@ public class WebSocketUtil {
     }
 
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key) {
-        try {
-            return (int) ((BDecimal) config.get(key)).floatValue();
-        } catch (Exception e) {
-            logger.warn("The value set for " + key + " is not a valid integer. The " + key + " value is set to " +
-                    Integer.MAX_VALUE);
-            return Integer.MAX_VALUE;
-        }
+        return (int) ((BDecimal) config.get(key)).floatValue();
     }
 
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key, int defaultValue) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketUtil.java
@@ -201,13 +201,17 @@ public class WebSocketUtil {
     }
 
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key) {
+        String value = config.get(key).toString();
+        int timeout;
         try {
-            return (int) ((BDecimal) config.get(key)).floatValue();
-        } catch (ArithmeticException e) {
-            logger.warn("The value set for {} needs to be less than {} .The {} value is set to {} ", key,
-                    Integer.MAX_VALUE, key, Integer.MAX_VALUE);
-            return Integer.MAX_VALUE;
+            timeout = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw WebSocketUtil.createErrorByType(new Exception("Invalid timeout value: " + value));
         }
+        if (timeout < 0 && timeout != -1) {
+            throw WebSocketUtil.createErrorByType(new Exception("Invalid timeout value: " + value));
+        }
+        return timeout;
     }
 
     public static int findTimeoutInSeconds(BMap<BString, Object> config, BString key, int defaultValue) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
@@ -85,7 +85,7 @@ public class Close {
         });
     }
 
-    private static int getConnectionClosureTimeout(Object bTimeoutInSecs, WebSocketConnectionInfo connectionInfo) {
+    public static int getConnectionClosureTimeout(Object bTimeoutInSecs, WebSocketConnectionInfo connectionInfo) {
         int timeoutInSecs = DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
         if (bTimeoutInSecs instanceof BDecimal) {
             timeoutInSecs = (int) ((BDecimal) bTimeoutInSecs).floatValue();
@@ -95,8 +95,8 @@ public class Close {
         return timeoutInSecs;
     }
 
-    private static ChannelFuture initiateConnectionClosure(List<BError> errors, int statusCode,
-            String reason, WebSocketConnectionInfo connectionInfo, CountDownLatch latch) throws IllegalAccessException {
+    public static ChannelFuture initiateConnectionClosure(List<BError> errors, int statusCode, String reason,
+            WebSocketConnectionInfo connectionInfo, CountDownLatch latch) throws IllegalAccessException {
         WebSocketConnection webSocketConnection = connectionInfo.getWebSocketConnection();
         ChannelFuture closeFuture;
         closeFuture = webSocketConnection.initiateConnectionClosure(statusCode, reason);

--- a/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
@@ -53,8 +53,8 @@ public class Close {
                     .getNativeData(WebSocketConstants.NATIVE_DATA_WEBSOCKET_CONNECTION_INFO);
             WebSocketObservabilityUtil.observeResourceInvocation(env, connectionInfo,
                     WebSocketConstants.RESOURCE_NAME_CLOSE);
-            int timeoutInSecs = getConnectionClosureTimeout(bTimeoutInSecs, connectionInfo);
             try {
+                int timeoutInSecs = getConnectionClosureTimeout(bTimeoutInSecs, connectionInfo);
                 CountDownLatch countDownLatch = new CountDownLatch(1);
                 List<BError> errors = new ArrayList<>(1);
                 ChannelFuture closeFuture = initiateConnectionClosure(errors, (int) statusCode, reason.getValue(),
@@ -84,13 +84,17 @@ public class Close {
     }
 
     public static int getConnectionClosureTimeout(Object bTimeoutInSecs, WebSocketConnectionInfo connectionInfo) {
-        int timeoutInSecs = 0;
-        if (bTimeoutInSecs instanceof BDecimal) {
-            timeoutInSecs = (int) ((BDecimal) bTimeoutInSecs).floatValue();
-        } else if (connectionInfo.getService() instanceof WebSocketServerService webSocketServerService) {
-            timeoutInSecs = webSocketServerService.getConnectionClosureTimeout();
+        try {
+            int timeoutInSecs = 0;
+            if (bTimeoutInSecs instanceof BDecimal) {
+                timeoutInSecs = Integer.parseInt(bTimeoutInSecs.toString());
+            } else if (connectionInfo.getService() instanceof WebSocketServerService webSocketServerService) {
+                timeoutInSecs = webSocketServerService.getConnectionClosureTimeout();
+            }
+            return timeoutInSecs;
+        } catch (Exception e) {
+            throw new RuntimeException("Invalid timeout value: " + bTimeoutInSecs, e);
         }
-        return timeoutInSecs;
     }
 
     public static ChannelFuture initiateConnectionClosure(List<BError> errors, int statusCode, String reason,

--- a/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
@@ -39,6 +39,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static io.ballerina.stdlib.websocket.WebSocketConstants.DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
+
 /**
  * {@code Get} is the GET action implementation of the HTTP Connector.
  */
@@ -84,13 +86,12 @@ public class Close {
     }
 
     private static int getConnectionClosureTimeout(Object bTimeoutInSecs, WebSocketConnectionInfo connectionInfo) {
-        int connectionClosureTimeout = 60;
         if (bTimeoutInSecs instanceof BDecimal) {
             return (int) ((BDecimal) bTimeoutInSecs).floatValue();
         } else if (connectionInfo.getService() instanceof WebSocketServerService webSocketServerService) {
             return webSocketServerService.getConnectionClosureTimeout();
         }
-        return connectionClosureTimeout;
+        return DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
     }
 
     private static ChannelFuture initiateConnectionClosure(List<BError> errors, int statusCode,

--- a/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
@@ -86,12 +86,13 @@ public class Close {
     }
 
     private static int getConnectionClosureTimeout(Object bTimeoutInSecs, WebSocketConnectionInfo connectionInfo) {
+        int timeoutInSecs = DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
         if (bTimeoutInSecs instanceof BDecimal) {
-            return (int) ((BDecimal) bTimeoutInSecs).floatValue();
+            timeoutInSecs = (int) ((BDecimal) bTimeoutInSecs).floatValue();
         } else if (connectionInfo.getService() instanceof WebSocketServerService webSocketServerService) {
-            return webSocketServerService.getConnectionClosureTimeout();
+            timeoutInSecs = webSocketServerService.getConnectionClosureTimeout();
         }
-        return DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
+        return timeoutInSecs;
     }
 
     private static ChannelFuture initiateConnectionClosure(List<BError> errors, int statusCode,

--- a/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/actions/websocketconnector/Close.java
@@ -39,8 +39,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static io.ballerina.stdlib.websocket.WebSocketConstants.DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
-
 /**
  * {@code Get} is the GET action implementation of the HTTP Connector.
  */
@@ -86,7 +84,7 @@ public class Close {
     }
 
     public static int getConnectionClosureTimeout(Object bTimeoutInSecs, WebSocketConnectionInfo connectionInfo) {
-        int timeoutInSecs = DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
+        int timeoutInSecs = 0;
         if (bTimeoutInSecs instanceof BDecimal) {
             timeoutInSecs = (int) ((BDecimal) bTimeoutInSecs).floatValue();
         } else if (connectionInfo.getService() instanceof WebSocketServerService webSocketServerService) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
@@ -20,7 +20,6 @@ package io.ballerina.stdlib.websocket.server;
 
 import io.ballerina.runtime.api.Runtime;
 import io.ballerina.runtime.api.types.ObjectType;
-import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
@@ -30,6 +29,8 @@ import io.ballerina.stdlib.websocket.WebSocketConstants;
 import io.ballerina.stdlib.websocket.WebSocketService;
 import io.ballerina.stdlib.websocket.WebSocketUtil;
 
+import static io.ballerina.runtime.api.utils.StringUtils.fromString;
+import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_DISPATCHER_KEY;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_VALIDATION_ENABLED;
 
@@ -58,7 +59,7 @@ public class WebSocketServerService extends WebSocketService {
             idleTimeoutInSeconds = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
                     WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT, 0);
             connectionClosureTimeout = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
-                    WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT);
+                    fromString(ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT));
             maxFrameSize = WebSocketUtil.findMaxFrameSize(configAnnotation);
             enableValidation = configAnnotation.getBooleanValue(ANNOTATION_ATTR_VALIDATION_ENABLED);
             if (configAnnotation.getStringValue(ANNOTATION_ATTR_DISPATCHER_KEY) != null) {
@@ -73,7 +74,7 @@ public class WebSocketServerService extends WebSocketService {
 
     @SuppressWarnings(WebSocketConstants.UNCHECKED) private BMap<BString, Object> getServiceConfigAnnotation() {
         ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
-        return (BMap<BString, Object>) serviceType.getAnnotation(StringUtils.fromString(
+        return (BMap<BString, Object>) serviceType.getAnnotation(fromString(
                 ModuleUtils.getPackageIdentifier() + ":" + WebSocketConstants.WEBSOCKET_ANNOTATION_CONFIGURATION));
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
@@ -32,7 +32,6 @@ import io.ballerina.stdlib.websocket.WebSocketUtil;
 
 import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_DISPATCHER_KEY;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_VALIDATION_ENABLED;
-import static io.ballerina.stdlib.websocket.WebSocketConstants.DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
 
 /**
  * WebSocket service for service dispatching.
@@ -59,7 +58,7 @@ public class WebSocketServerService extends WebSocketService {
             idleTimeoutInSeconds = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
                     WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT, 0);
             connectionClosureTimeout = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
-                    WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT, DEFAULT_CONNECTION_CLOSURE_TIMEOUT);
+                    WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT);
             maxFrameSize = WebSocketUtil.findMaxFrameSize(configAnnotation);
             enableValidation = configAnnotation.getBooleanValue(ANNOTATION_ATTR_VALIDATION_ENABLED);
             if (configAnnotation.getStringValue(ANNOTATION_ATTR_DISPATCHER_KEY) != null) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
@@ -44,6 +44,7 @@ public class WebSocketServerService extends WebSocketService {
     private int idleTimeoutInSeconds = 0;
     private boolean enableValidation = true;
     private String dispatchingKey = null;
+    private int connectionClosureTimeout;
 
     public WebSocketServerService(BObject service, Runtime runtime, String basePath) {
         super(service, runtime);
@@ -56,6 +57,8 @@ public class WebSocketServerService extends WebSocketService {
             negotiableSubProtocols = WebSocketUtil.findNegotiableSubProtocols(configAnnotation);
             idleTimeoutInSeconds = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
                     WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT, 0);
+            connectionClosureTimeout = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
+                    WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT, 60);
             maxFrameSize = WebSocketUtil.findMaxFrameSize(configAnnotation);
             enableValidation = configAnnotation.getBooleanValue(ANNOTATION_ATTR_VALIDATION_ENABLED);
             if (configAnnotation.getStringValue(ANNOTATION_ATTR_DISPATCHER_KEY) != null) {
@@ -100,5 +103,9 @@ public class WebSocketServerService extends WebSocketService {
 
     public String getBasePath() {
         return basePath;
+    }
+
+    public int getConnectionClosureTimeout() {
+        return connectionClosureTimeout;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/server/WebSocketServerService.java
@@ -32,6 +32,7 @@ import io.ballerina.stdlib.websocket.WebSocketUtil;
 
 import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_DISPATCHER_KEY;
 import static io.ballerina.stdlib.websocket.WebSocketConstants.ANNOTATION_ATTR_VALIDATION_ENABLED;
+import static io.ballerina.stdlib.websocket.WebSocketConstants.DEFAULT_CONNECTION_CLOSURE_TIMEOUT;
 
 /**
  * WebSocket service for service dispatching.
@@ -58,7 +59,7 @@ public class WebSocketServerService extends WebSocketService {
             idleTimeoutInSeconds = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
                     WebSocketConstants.ANNOTATION_ATTR_IDLE_TIMEOUT, 0);
             connectionClosureTimeout = WebSocketUtil.findTimeoutInSeconds(configAnnotation,
-                    WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT, 60);
+                    WebSocketConstants.ANNOTATION_ATTR_CONNECTION_CLOSURE_TIMEOUT, DEFAULT_CONNECTION_CLOSURE_TIMEOUT);
             maxFrameSize = WebSocketUtil.findMaxFrameSize(configAnnotation);
             enableValidation = configAnnotation.getBooleanValue(ANNOTATION_ATTR_VALIDATION_ENABLED);
             if (configAnnotation.getStringValue(ANNOTATION_ATTR_DISPATCHER_KEY) != null) {


### PR DESCRIPTION
## Purpose
> $subject

Resolves [Introduce Service Config Annotation for connectionClosureTimeout](https://github.com/ballerina-platform/ballerina-library/issues/7697)

## Examples
```ballerina
@websocket:ServiceConfig {
    connectionClosureTimeout: 10
}
service /ws on new websocket:Listener(9090) {
    resource function get .() returns websocket:Service {
        return new WsService();
    }
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the specification
- [x] Updated the changelog
- [x] Added tests
- [ ] Checked native-image compatibility
