### PR TITLE
Fix response parsing issue in a JSON stream

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
@@ -44,6 +44,7 @@ import static io.ballerina.stdlib.websocket.WebSocketResourceCallback.sendCloseF
 import static io.ballerina.stdlib.websocket.WebSocketResourceDispatcher.dispatchOnError;
 import static io.ballerina.stdlib.websocket.actions.websocketconnector.WebSocketConnector.fromText;
 import static io.ballerina.stdlib.websocket.actions.websocketconnector.WebSocketConnector.release;
+import static org.ballerinalang.langlib.value.ToJsonString.toJsonString;
 
 /**
  * Call back class registered for returning streams.
@@ -67,9 +68,8 @@ public class ReturnStreamUnitCallBack implements Handler {
     public void notifySuccess(Object response) {
         if (response != null) {
             PromiseCombiner promiseCombiner = new PromiseCombiner(ImmediateEventExecutor.INSTANCE);
-            String content;
             if (response instanceof BError) {
-                content = ((BError) response).getMessage();
+                String content = ((BError) response).getMessage();
                 webSocketConnection.terminateConnection(1011,
                         String.format("streaming failed: %s", content));
             } else {
@@ -78,8 +78,11 @@ public class ReturnStreamUnitCallBack implements Handler {
                     sendCloseFrame(contentObj, connectionInfo);
                     return;
                 }
-                content = contentObj.toString();
-                sendTextMessageStream(StringUtils.fromString(content), promiseCombiner);
+                if (contentObj instanceof BString bString) {
+                    sendTextMessageStream(bString, promiseCombiner);
+                } else {
+                    sendTextMessageStream(toJsonString(contentObj), promiseCombiner);
+                }
                 Thread.startVirtualThread(() -> {
                     Map<String, Object> properties = ModuleUtils.getProperties(STREAMING_NEXT_FUNCTION);
                     StrandMetadata strandMetadata = new StrandMetadata(true, properties);


### PR DESCRIPTION
## Purpose
Fixes an issue similar to [#7720](https://github.com/ballerina-platform/ballerina-library/issues/7720), where returning a JSON with escaped double quotes messages as a stream, results in a data binding error on the client side.

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [x] Added tests
- [ ] Checked native-image compatibility
