### PR TITLE
non compatible HTTP version error

### DIFF
--- a/ballerina/service_endpoint.bal
+++ b/ballerina/service_endpoint.bal
@@ -79,6 +79,11 @@ public class Listener {
         self.instanceId = uuid();
         self.config = config;
         if 'listener is http:Listener {
+            http:HttpVersion version = 'listener.getConfig().httpVersion;
+			if version!=http:HTTP_1_1{
+                string errorMessage = "HTTP listener has non compatible HTTP version: " + version.toString();
+				return error Error(errorMessage);
+			}
            self.httpListener = 'listener;
         } else {
            self.port = 'listener;


### PR DESCRIPTION
## Purpose
Creation of a websocket:Listener with http:Listener was not working properly, because of http version mismatch between http:Listener and websocket:Listener, as http:Listener uses http version 2.0 by default, and websocket:Listener uses http version 1.1 which cause initialization of websocket:Listener to fail.

The following response is sent by program because of this mismatch.
Response:
```
Status Code: 500 Internal Server Error
Request Headers
Sec-WebSocket-Version: 13
Sec-WebSocket-Key: PWM4ryWB6hBgeVhJbUyEvA==
Connection: Upgrade
Upgrade: websocket
Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
Host: localhost:9090
```

Code:
```
import ballerina/http;
import ballerina/websocket;

listener http:Listener 'listener = check new(9090);
listener websocket:Listener wsListener = new('listener);

service /ws on wsListener {
    resource function get .(string id, string 'type) returns websocket:Service {
        if 'type == ORDER_TYPE {
            ...
        } else {
            ...
        }
    }
}
```

After merging this change, the following error will be return if version mismatch is detected.
**"HTTP listener has non compatible HTTP version: 2.0"**


## Checklist
- [ ] Linked to an issue : [Issue #4764](https://github.com/ballerina-platform/ballerina-library/issues/4764)
- [ ] Updated the specification : Updates service-endpoint.bal file

