### PR TITLE
Fix streaming response permanently blocking inbound frame reads after the first element

### DIFF
--- a/ballerina/tests/stream_test.bal
+++ b/ballerina/tests/stream_test.bal
@@ -246,3 +246,22 @@ public function testConcurrentRequestDuringStreamResponse() returns Error? {
         }
     }
 }
+
+// Regression test for a bug where the server only re-armed reading of the next inbound frame after the
+// *first* stream element (see testConcurrentRequestDuringStreamResponse above), then never again for the
+// rest of the stream. That meant only a request sent immediately after the first element was ever
+// guaranteed to be processed; every later request would sit queued and undelivered for the lifetime of the
+// stream. This test sends a request after each of several stream elements (not just the first) to make
+// sure inbound frames keep being read throughout.
+@test:Config {}
+public function testMultipleConcurrentRequestsDuringStreamResponse() returns Error? {
+    Client wsClient = check new ("ws://localhost:21402/onConcurrentRequest/");
+    check wsClient->writeMessage({event: "subscribe"});
+    foreach int i in 1 ... 5 {
+        int data = check wsClient->readMessage();
+        test:assertEquals(data, i);
+        check wsClient->writeMessage("Hello");
+        int res = check wsClient->readMessage();
+        test:assertEquals(res, -1, string `onMessage response was not received right after stream element ${i}`);
+    }
+}

--- a/ballerina/tests/stream_test.bal
+++ b/ballerina/tests/stream_test.bal
@@ -247,14 +247,6 @@ public function testConcurrentRequestDuringStreamResponse() returns Error? {
     }
 }
 
-// Regression test for a bug where the server only re-armed reading of the next inbound frame after the
-// *first* stream element (see testConcurrentRequestDuringStreamResponse above), then never again for the
-// rest of the stream. That meant only a request sent immediately after the first element was ever
-// guaranteed to be processed; every later request would sit queued and undelivered for the lifetime of the
-// stream. This test sends a request after each of several distinct stream elements (not just the first)
-// and confirms every one eventually gets a response - without assuming a request's response is the very
-// next message read, since a stream element and a request's response can legitimately interleave in
-// either order.
 @test:Config {}
 public function testMultipleConcurrentRequestsDuringStreamResponse() returns Error? {
     Client wsClient = check new ("ws://localhost:21402/onConcurrentRequest/");

--- a/ballerina/tests/stream_test.bal
+++ b/ballerina/tests/stream_test.bal
@@ -251,17 +251,31 @@ public function testConcurrentRequestDuringStreamResponse() returns Error? {
 // *first* stream element (see testConcurrentRequestDuringStreamResponse above), then never again for the
 // rest of the stream. That meant only a request sent immediately after the first element was ever
 // guaranteed to be processed; every later request would sit queued and undelivered for the lifetime of the
-// stream. This test sends a request after each of several stream elements (not just the first) to make
-// sure inbound frames keep being read throughout.
+// stream. This test sends a request after each of several distinct stream elements (not just the first)
+// and confirms every one eventually gets a response - without assuming a request's response is the very
+// next message read, since a stream element and a request's response can legitimately interleave in
+// either order.
 @test:Config {}
 public function testMultipleConcurrentRequestsDuringStreamResponse() returns Error? {
     Client wsClient = check new ("ws://localhost:21402/onConcurrentRequest/");
     check wsClient->writeMessage({event: "subscribe"});
-    foreach int i in 1 ... 5 {
-        int data = check wsClient->readMessage();
-        test:assertEquals(data, i);
-        check wsClient->writeMessage("Hello");
+    int requestsToSend = 5;
+    int requestsSent = 0;
+    int acksReceived = 0;
+    int lastStreamValue = 0;
+    while acksReceived < requestsToSend {
         int res = check wsClient->readMessage();
-        test:assertEquals(res, -1, string `onMessage response was not received right after stream element ${i}`);
+        if res == -1 {
+            acksReceived += 1;
+            continue;
+        }
+        test:assertTrue(res > lastStreamValue,
+                string `expected an increasing stream value greater than ${lastStreamValue}, got ${res}`);
+        lastStreamValue = res;
+        if requestsSent < requestsToSend {
+            check wsClient->writeMessage("Hello");
+            requestsSent += 1;
+        }
     }
+    test:assertEquals(requestsSent, requestsToSend);
 }

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina WebSocket packa
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [Fix streaming response permanently blocking inbound frame reads after the first element](https://github.com/ballerina-platform/ballerina-library/issues/8923)
+
 ## [2.15.3] - 2026-05-11
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
@@ -89,10 +89,6 @@ public class ReturnStreamUnitCallBack implements Handler {
                     try {
                         Object result = runtime.callMethod(bObject, STREAMING_NEXT_FUNCTION, strandMetadata);
                         // Re-arm the next inbound frame read for every stream element, not just the first
-                        // (WebSocketResourceCallback#notifySuccess does this for the first element). Without
-                        // this, autoRead stays disabled for the lifetime of the stream after element #1, so
-                        // frames arriving on this connection (e.g. a client ping) are queued forever and never
-                        // dispatched by WebSocketMessageQueueHandler.
                         webSocketConnection.readNextFrame();
                         this.notifySuccess(result);
                     } catch (BError bError) {

--- a/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
@@ -88,6 +88,12 @@ public class ReturnStreamUnitCallBack implements Handler {
                     StrandMetadata strandMetadata = new StrandMetadata(true, properties);
                     try {
                         Object result = runtime.callMethod(bObject, STREAMING_NEXT_FUNCTION, strandMetadata);
+                        // Re-arm the next inbound frame read for every stream element, not just the first
+                        // (WebSocketResourceCallback#notifySuccess does this for the first element). Without
+                        // this, autoRead stays disabled for the lifetime of the stream after element #1, so
+                        // frames arriving on this connection (e.g. a client ping) are queued forever and never
+                        // dispatched by WebSocketMessageQueueHandler.
+                        webSocketConnection.readNextFrame();
                         this.notifySuccess(result);
                     } catch (BError bError) {
                         this.notifyFailure(bError);


### PR DESCRIPTION
## Purpose

Fixes ballerina-library#8923.

`WebSocketResourceCallback#notifySuccess` re-arms the next inbound frame read (`webSocketConnection.readNextFrame()`) exactly once, right after fetching the *first* element of a service-returned `stream<...>` — but every subsequent element is driven by `ReturnStreamUnitCallBack`'s own recursive fetch loop, which never called `readNextFrame()` at all.

Since the server disables Netty `autoRead` for the life of a WebSocket connection and gates every inbound frame behind an explicit `readNextFrame()` call (`WebSocketMessageQueueHandler` in `module-ballerina-http`), this meant: once a streaming response moved past its first element, the connection permanently stopped reading new inbound frames — a client `ping`, an `onMessage` frame, anything — for the rest of that stream's lifetime. Those frames aren't delayed, they're queued forever and never dispatched.

This is a regression from #1565 (closing #7844): that PR correctly fixed inbound dispatch being *delayed* behind an active stream by moving the single `readNextFrame()` call earlier (from "when the stream fully completes" to "right after the first element"), but never made the re-arm recur per element.

Root-caused while investigating an intermittent, CI-only failure in `module-ballerina-graphql`'s new client-subscription keep-alive feature (https://github.com/ballerina-platform/module-ballerina-graphql/pull/2534): a client keep-alive `ping` sent while a subscription's result stream is actively emitting events would, in roughly 2 out of every 5 pings, simply never be received server-side.

The fix is one line in `ReturnStreamUnitCallBack`'s recursive fetch, mirroring the existing call site in `WebSocketResourceCallback`:

```java
Object result = runtime.callMethod(bObject, STREAMING_NEXT_FUNCTION, strandMetadata);
webSocketConnection.readNextFrame();   // <-- added
this.notifySuccess(result);
```

## Examples

Not applicable — this is an internal frame-dispatch fix with no public API change. Reproduction is covered by the added test below: a service resource returns a `stream<int, error?>`, and a client sends a request after each of several stream elements (not just the first), asserting every request eventually gets a response.

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed WebSocket streaming behavior so inbound frame reads are re-armed for every streamed element, preventing reads from stopping after the first element.
- Added a regression test that sends multiple inbound requests throughout a streaming response and verifies each request receives a corresponding response even when stream values and acknowledgements are interleaved.
- Updated the changelog to document the streaming fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->