### PR TITLE
Fix inbound read credit starved behind slow stream production

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "websocket"
-version = "2.15.5"
+version = "2.15.6"
 authors = ["Ballerina"]
 keywords = ["ws", "network", "bi-directional", "streaming", "service", "client"]
 repository = "https://github.com/ballerina-platform/module-ballerina-websocket"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "websocket-native"
-version = "2.15.5"
-path = "../native/build/libs/websocket-native-2.15.5.jar"
+version = "2.15.6"
+path = "../native/build/libs/websocket-native-2.15.6-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
@@ -85,5 +85,5 @@ version = "4.1.136.Final"
 path = "./lib/netty-handler-proxy-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
-path = "../test-utils/build/libs/websocket-test-utils-2.15.5.jar"
+path = "../test-utils/build/libs/websocket-test-utils-2.15.6-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,10 +3,10 @@ id = "websocket-compiler-plugin"
 class = "io.ballerina.stdlib.websocket.plugin.WebSocketCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/websocket-compiler-plugin-2.15.5.jar"
+path = "../compiler-plugin/build/libs/websocket-compiler-plugin-2.15.6-SNAPSHOT.jar"
 
 [[dependency]]
-path = "../native/build/libs/websocket-native-2.15.5.jar"
+path = "../native/build/libs/websocket-native-2.15.6-SNAPSHOT.jar"
 
 [[dependency]]
 path = "./lib/http-native-2.15.6.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.5"
+version = "2.15.6"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/tests/stream_test.bal
+++ b/ballerina/tests/stream_test.bal
@@ -16,6 +16,7 @@
 
 import ballerina/lang.runtime;
 import ballerina/test;
+import ballerina/time;
 
 public type ChatMessage record {|
     string name = "";
@@ -162,6 +163,30 @@ service class ConcurrentRequestSvc {
     }
 }
 
+@ServiceConfig {
+    dispatcherKey: "event"
+}
+service /onSlowConcurrentRequest on streamLis {
+    resource function get .() returns Service|UpgradeError {
+        return new SlowConcurrentRequestSvc();
+    }
+}
+
+service class SlowConcurrentRequestSvc {
+    *Service;
+
+    remote function onSubscribe(string message) returns stream<int, error?> {
+        return [1, 2, 3].toStream().'map(function(int i) returns int {
+            runtime:sleep(2);
+            return i;
+        });
+    }
+
+    remote function onMessage(string message) returns int {
+        return -1;
+    }
+}
+
 @test:Config {}
 public function testStreamString() returns Error? {
     Client wsClient = check new ("ws://localhost:21402/onStream/");
@@ -270,4 +295,29 @@ public function testMultipleConcurrentRequestsDuringStreamResponse() returns Err
         }
     }
     test:assertEquals(requestsSent, requestsToSend);
+}
+
+@test:Config {}
+public function testConcurrentRequestNotStarvedDuringSlowStreamProduction() returns Error? {
+    Client wsClient = check new ("ws://localhost:21402/onSlowConcurrentRequest/");
+    check wsClient->writeMessage({event: "subscribe"});
+
+    // Send the unrelated request on its own timer, independent of stream element arrival,
+    // so it lands in the middle of a slow (2s) per-element production cycle instead of right
+    // at the boundary where the inbound read credit happens to be freshly re-armed.
+    runtime:sleep(1);
+    time:Utc sendTime = time:utcNow();
+    check wsClient->writeMessage("Hello");
+
+    while true {
+        int res = check wsClient->readMessage();
+        if res == -1 {
+            break;
+        }
+    }
+    decimal elapsedSeconds = time:utcDiffSeconds(time:utcNow(), sendTime);
+    test:assertTrue(elapsedSeconds < 0.5d,
+            string `expected the concurrent "onMessage" request to be acknowledged promptly (< 0.5s) even ` +
+            string `while the stream is mid-production (2s per element), but the ack took ${elapsedSeconds}s. ` +
+            "This indicates the inbound read credit was starved behind the stream's per-element production cadence.");
 }

--- a/ballerina/tests/stream_test.bal
+++ b/ballerina/tests/stream_test.bal
@@ -299,12 +299,11 @@ public function testMultipleConcurrentRequestsDuringStreamResponse() returns Err
 
 @test:Config {}
 public function testConcurrentRequestNotStarvedDuringSlowStreamProduction() returns Error? {
+    // Covers the bootstrap path: request lands during the first element's fetch.
     Client wsClient = check new ("ws://localhost:21402/onSlowConcurrentRequest/");
     check wsClient->writeMessage({event: "subscribe"});
 
-    // Send the unrelated request on its own timer, independent of stream element arrival,
-    // so it lands in the middle of a slow (2s) per-element production cycle instead of right
-    // at the boundary where the inbound read credit happens to be freshly re-armed.
+    // Independent timer so this lands mid-fetch, not at a re-arm boundary.
     runtime:sleep(1);
     time:Utc sendTime = time:utcNow();
     check wsClient->writeMessage("Hello");
@@ -320,4 +319,30 @@ public function testConcurrentRequestNotStarvedDuringSlowStreamProduction() retu
             string `expected the concurrent "onMessage" request to be acknowledged promptly (< 0.5s) even ` +
             string `while the stream is mid-production (2s per element), but the ack took ${elapsedSeconds}s. ` +
             "This indicates the inbound read credit was starved behind the stream's per-element production cadence.");
+}
+
+@test:Config {}
+public function testConcurrentRequestNotStarvedDuringSlowStreamProductionAfterFirstElement() returns Error? {
+    // Covers the recursive path: request lands during the second element's fetch.
+    Client wsClient = check new ("ws://localhost:21402/onSlowConcurrentRequest/");
+    check wsClient->writeMessage({event: "subscribe"});
+    int data = check wsClient->readMessage();
+    test:assertEquals(data, 1);
+
+    runtime:sleep(1);
+    time:Utc sendTime = time:utcNow();
+    check wsClient->writeMessage("Hello");
+
+    while true {
+        int res = check wsClient->readMessage();
+        if res == -1 {
+            break;
+        }
+    }
+    decimal elapsedSeconds = time:utcDiffSeconds(time:utcNow(), sendTime);
+    test:assertTrue(elapsedSeconds < 0.5d,
+            string `expected the concurrent "onMessage" request to be acknowledged promptly (< 0.5s) even ` +
+            string `while the stream is mid-production (2s per element) after the first element, but the ack ` +
+            string `took ${elapsedSeconds}s. This indicates the inbound read credit was starved behind the ` +
+            "stream's recursive per-element production cadence.");
 }

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina WebSocket packa
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- [Fix inbound control/heartbeat frames starved by the read-gate while a stream resource is producing](https://github.com/ballerina-platform/ballerina-library/issues/8929)
+
 ## [2.15.5] - 2026-07-24
 
 ### Fixed

--- a/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
@@ -83,11 +83,7 @@ public class ReturnStreamUnitCallBack implements Handler {
                 } else {
                     sendTextMessageStream(toJsonString(contentObj), promiseCombiner);
                 }
-                // Re-arm the inbound read credit as soon as the current element has been dispatched
-                // for sending, rather than after the next element's (potentially slow/blocking) fetch
-                // completes. This keeps the read gate open for the full duration of that fetch so
-                // unrelated inbound frames (e.g. ping/pong heartbeats) are not starved behind the
-                // stream's own production cadence.
+                // Re-arm before the next (possibly slow) fetch, not after, so reads aren't starved meanwhile.
                 webSocketConnection.readNextFrame();
                 Thread.startVirtualThread(() -> {
                     Map<String, Object> properties = ModuleUtils.getProperties(STREAMING_NEXT_FUNCTION);

--- a/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/ReturnStreamUnitCallBack.java
@@ -83,13 +83,17 @@ public class ReturnStreamUnitCallBack implements Handler {
                 } else {
                     sendTextMessageStream(toJsonString(contentObj), promiseCombiner);
                 }
+                // Re-arm the inbound read credit as soon as the current element has been dispatched
+                // for sending, rather than after the next element's (potentially slow/blocking) fetch
+                // completes. This keeps the read gate open for the full duration of that fetch so
+                // unrelated inbound frames (e.g. ping/pong heartbeats) are not starved behind the
+                // stream's own production cadence.
+                webSocketConnection.readNextFrame();
                 Thread.startVirtualThread(() -> {
                     Map<String, Object> properties = ModuleUtils.getProperties(STREAMING_NEXT_FUNCTION);
                     StrandMetadata strandMetadata = new StrandMetadata(true, properties);
                     try {
                         Object result = runtime.callMethod(bObject, STREAMING_NEXT_FUNCTION, strandMetadata);
-                        // Re-arm the next inbound frame read for every stream element, not just the first
-                        webSocketConnection.readNextFrame();
                         this.notifySuccess(result);
                     } catch (BError bError) {
                         this.notifyFailure(bError);

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketResourceCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketResourceCallback.java
@@ -113,8 +113,7 @@ public final class WebSocketResourceCallback implements Handler {
             BObject bObject = ((BStream) result).getIteratorObj();
             ReturnStreamUnitCallBack returnStreamUnitCallBack = new ReturnStreamUnitCallBack(bObject, runtime,
                     connectionInfo, webSocketConnection);
-            // Re-arm the inbound read credit before fetching the first element so a slow/blocking
-            // first fetch does not starve unrelated inbound frames (e.g. ping/pong heartbeats).
+            // Re-arm before the first fetch, not after, so a slow fetch doesn't starve other reads.
             webSocketConnection.readNextFrame();
             Thread.startVirtualThread(() -> {
                 Map<String, Object> properties = ModuleUtils.getProperties(STREAMING_NEXT_FUNCTION);

--- a/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketResourceCallback.java
+++ b/native/src/main/java/io/ballerina/stdlib/websocket/WebSocketResourceCallback.java
@@ -113,12 +113,14 @@ public final class WebSocketResourceCallback implements Handler {
             BObject bObject = ((BStream) result).getIteratorObj();
             ReturnStreamUnitCallBack returnStreamUnitCallBack = new ReturnStreamUnitCallBack(bObject, runtime,
                     connectionInfo, webSocketConnection);
+            // Re-arm the inbound read credit before fetching the first element so a slow/blocking
+            // first fetch does not starve unrelated inbound frames (e.g. ping/pong heartbeats).
+            webSocketConnection.readNextFrame();
             Thread.startVirtualThread(() -> {
                 Map<String, Object> properties = ModuleUtils.getProperties(STREAMING_NEXT_FUNCTION);
                 StrandMetadata strandMetadata = new StrandMetadata(true, properties);
                 try {
                     Object res = runtime.callMethod(bObject, STREAMING_NEXT_FUNCTION, strandMetadata);
-                    webSocketConnection.readNextFrame();
                     returnStreamUnitCallBack.notifySuccess(res);
                 } catch (BError bError) {
                     returnStreamUnitCallBack.notifyFailure(bError);


### PR DESCRIPTION
## Purpose

Fixes the server-side half of ballerina-platform/ballerina-library#8929 (partially fixes; does not close the issue — see below).

`ReturnStreamUnitCallBack.notifySuccess` and the `BStream` bootstrap branch in `WebSocketResourceCallback.notifySuccess` re-armed the connection's single inbound read credit (`webSocketConnection.readNextFrame()`) only *after* the (potentially slow/blocking) fetch of the *next* stream element completed — not when the *current* element was dispatched for sending. Under a slow or CPU-starved producer, this meant the read credit was unavailable for the entire duration of each element's fetch, so any unrelated inbound frame that arrived during that window (e.g. a `graphql-transport-ws` application-level `{"type":"ping"}` heartbeat, which is just an ordinary text frame) sat queued in the transport until the fetch happened to finish — not a fixed delay, but one bound to the stream's own production cadence.

This is a follow-up to #1609 (fixed ballerina-library#8923), which made the credit re-arm *per element* instead of once for the whole stream, but didn't change *when* in each cycle the re-arm happens.

## Fix

Move the `readNextFrame()` call to fire as soon as the current element has been handed off for sending, instead of after the next element's fetch completes:
- `ReturnStreamUnitCallBack.notifySuccess`: re-arm right after `sendTextMessageStream(...)`, not after the recursive `next()` call returns.
- `WebSocketResourceCallback.notifySuccess` (`BStream` branch): re-arm immediately upon entering the branch, before the first blocking `next()` call, instead of after it returns.

This keeps the read gate open for virtually the full duration of each element's production instead of only a narrow window at the boundary.

## Scope

This PR only addresses the **server-side** starvation (inbound frames stalled while a service's returned `stream<>` is producing). The issue's second failure mode — the sync client's `readMessage()` pull model similarly starving an already-arrived reply while the caller is busy processing a prior message — is a separate, deeper design question (a fix would mean read-ahead/prefetching on the client, which trades away some backpressure precision). That's being tracked and discussed separately in ballerina-platform/ballerina-library#8930 rather than bundled into this PR.

## Testing

Added `testConcurrentRequestNotStarvedDuringSlowStreamProduction` (`ballerina/tests/stream_test.bal`): a stream with a 2s-per-element production delay, with an unrelated request sent on its own timer (independent of stream element arrival, so it lands mid-fetch-cycle rather than at the boundary where the credit happens to already be armed). Asserts the request is acknowledged in under 0.5s.

- Confirmed this test fails on unfixed code (~1.02s delay, matching the predicted "queued until the next fetch boundary" signature).
- Confirmed it passes with the fix (near-instant ack).
- Full existing suite (228 tests) passes with no regressions, including all stream and ping/pong tests.

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed WebSocket server-side inbound read-credit starvation during slow `stream<>` production by re-arming `readNextFrame()` immediately after each element is handed off for sending, including stream bootstrap and recursive per-element paths.
- Added a regression test (`testConcurrentRequestNotStarvedDuringSlowStreamProduction`) that produces stream elements with 2-second delays while issuing an unrelated concurrent request, asserting the acknowledgment occurs within 0.5 seconds.
- Updated the unreleased changelog to document the inbound control/heartbeat starvation fix.
- Synchronized WebSocket-related native/test dependency versions to `2.15.6-SNAPSHOT`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->