### PR TITLE
Update http dependency version

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -21,8 +21,8 @@ path = "../native/build/libs/websocket-native-2.15.6-SNAPSHOT.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "http-native"
-version = "2.15.6"
-path = "./lib/http-native-2.15.6.jar"
+version = "2.15.8"
+path = "./lib/http-native-2.15.8-20260903-142000-52022c1.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -9,4 +9,4 @@ path = "../compiler-plugin/build/libs/websocket-compiler-plugin-2.15.6-SNAPSHOT.
 path = "../native/build/libs/websocket-native-2.15.6-SNAPSHOT.jar"
 
 [[dependency]]
-path = "./lib/http-native-2.15.6.jar"
+path = "./lib/http-native-2.15.8-20260903-142000-52022c1.jar"

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ stdlibJwtVersion=2.15.1
 stdlibOAuth2Version=2.15.0
 
 # Level 05
-stdlibHttpVersion=2.15.6
+stdlibHttpVersion=2.15.8-20260903-142000-52022c1
 
 # Ballerinax Observer
 observeVersion=1.5.1


### PR DESCRIPTION
## Summary
- Bump `stdlibHttpVersion` in `gradle.properties` to `2.15.8-20260903-142000-52022c1`
- Regenerate `ballerina/Ballerina.toml` and `ballerina/CompilerPlugin.toml` to point at the corresponding `http-native` jar

## Test plan
- [x] `./gradlew clean build` (native, test-utils, compiler-plugin, and ballerina modules, including tests) passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `stdlibHttpVersion` to `2.15.8-20260903-142000-52022c1`.
- Regenerated Ballerina dependency files to reference the matching `http-native` JAR.
- Verified the update with `./gradlew clean build`, including tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->