### PR TITLE
Update header formatting in README.md

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,7 +2,7 @@
 
 This module provides APIs for connecting to and interacting with WebSocket endpoints, through two types of network entry points: the `Client` and the `Listener`.
 
-## Key Features
+### Key Features
 
 - WebSocket Client and Listener for bi-directional communication
 - Control message handling (ping/pong, close)


### PR DESCRIPTION
## Purpose

Fixes the README so the WSO2 Integration Store correctly displays the Key Features section for this connector. `## Key Features` is demoted to `### Key Features`, nesting it under `## Overview` to match the Store's existing parsing convention.

## Examples

N/A — documentation-only change, no code or behavior affected.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Documentation
- Changed the `Key Features` heading in `ballerina/README.md` from `##` to `###`.
- Nested the section under `Overview` for correct WSO2 Integration Store display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->